### PR TITLE
Fixed threading issue when trying to update variables…

### DIFF
--- a/LeanplumSample/Assets/WebPlayerTemplates/DoNotCompile/Leanplum/LeanplumNative/VarCache.cs
+++ b/LeanplumSample/Assets/WebPlayerTemplates/DoNotCompile/Leanplum/LeanplumNative/VarCache.cs
@@ -348,7 +348,7 @@ namespace LeanplumSDK
                 var parameters = new Dictionary<string, string>();
                 parameters[Constants.Params.VARIABLES] = Json.Serialize(valuesFromClient);
                 parameters[Constants.Params.KINDS] = Json.Serialize(defaultKinds);
-                LeanplumRequest.Post(Constants.Methods.SET_VARS, parameters).SendNow();
+                LeanplumUnityHelper.QueueOnMainThread(() => LeanplumRequest.Post(Constants.Methods.SET_VARS, parameters).SendNow());
                 return true;
             }
             return false;


### PR DESCRIPTION
…using the Unity Native implementation

The issue was that the request was sent from the web socket thread, but Unity web requests can only be created and sent on the main thread.