### PR TITLE
Made SocketIO implementation compatible with .NET Standard

### DIFF
--- a/LeanplumSample/Assets/LeanplumSDK/LeanplumNative/Plugins/socketio/Client.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/LeanplumNative/Plugins/socketio/Client.cs
@@ -530,7 +530,7 @@ namespace LeanplumSDK.SocketIOClient
                         this.outboundQueue.Enqueue(msg.Encoded);
                         if (this.HeartBeatTimerEvent != null)
                         {
-                            this.HeartBeatTimerEvent.BeginInvoke(this, EventArgs.Empty, EndAsyncEvent, null);
+                            this.HeartBeatTimerEvent.BeginInvoke(this, EventArgs.Empty, EndAsyncEvent, this.HeartBeatTimerEvent);
                         }
                     }
                 }
@@ -543,8 +543,7 @@ namespace LeanplumSDK.SocketIOClient
         }
         private void EndAsyncEvent(IAsyncResult result)
         {
-            var ar = (System.Runtime.Remoting.Messaging.AsyncResult)result;
-            var invokedMethod = (EventHandler)ar.AsyncDelegate;
+            var invokedMethod = (EventHandler)result.AsyncState;
             
             try
             {


### PR DESCRIPTION
`System.Runtime.Remoting.Messaging.AsyncResult` is not part of .NET Standard 2.0.

My fix is based on the last example here:
https://msdn.microsoft.com/en-us/library/2e08f6yc(v=vs.85).aspx