### PR TITLE
fixed issue with iOS behaviour when no userId

### DIFF
--- a/LeanplumSample/Assets/Plugins/iOS/LeanplumIOSBridge.mm
+++ b/LeanplumSample/Assets/Plugins/iOS/LeanplumIOSBridge.mm
@@ -294,7 +294,9 @@ extern "C"
         NSDictionary *dictionary = [NSJSONSerialization JSONObjectWithData:data
                                                                    options:NSUTF8StringEncoding
                                                                      error:nil];
-        [Leanplum startWithUserId:leanplum_createNSString(userId) userAttributes:dictionary
+        
+        NSString *userIdString = userId != NULL ? [NSString stringWithUTF8String:userId] : nil;
+        [Leanplum startWithUserId:userIdString userAttributes:dictionary
                   responseHandler:^(BOOL success) {
                       int res = [@(success) intValue];
                       UnitySendMessage(__LPgameObject, "NativeCallback",


### PR DESCRIPTION
The documented and android behaviour of the SDK is to set the deviceId as the userId when no userId is provided. However the iOS bridge file is setting an empty string in these instances. This PR fixes that inconsistency.