### PR TITLE
exposed track purchase api

### DIFF
--- a/Android/src/main/java/com/leanplum/UnityBridge.java
+++ b/Android/src/main/java/com/leanplum/UnityBridge.java
@@ -175,6 +175,12 @@ public class UnityBridge {
     Leanplum.start(bridgeContext, userId, attributes);
   }
 
+  public static void trackPurchase(String eventName, double value, String currencyCode,
+      String jsonParameters) {
+    Leanplum.trackPurchase(eventName, value, currencyCode,
+        JsonConverter.fromJson(jsonParameters));
+  }
+
   public static void track(String eventName, double value, String info,
       String jsonParameters) {
     Leanplum.track(eventName, value, info,

--- a/LeanplumSample/Assets/LeanplumSDK/Leanplum.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/Leanplum.cs
@@ -474,6 +474,17 @@ namespace LeanplumSDK
         ///     any value of your choosing, and will show up in the dashboard.
         ///     To track purchases, use Leanplum.PURCHASE_EVENT_NAME as the event name.
         /// </summary>
+        public static void TrackPurchase(string eventName, double value, string currencyCode,
+            IDictionary<string, object> parameters)
+        {
+            LeanplumFactory.SDK.TrackPurchase(eventName, value, currencyCode, parameters);
+        }
+
+        /// <summary>
+        ///     Logs a particular event in your application. The string can be
+        ///     any value of your choosing, and will show up in the dashboard.
+        ///     To track purchases, use Leanplum.PURCHASE_EVENT_NAME as the event name.
+        /// </summary>
         public static void Track(string eventName, double value, string info,
             IDictionary<string, object> parameters)
         {

--- a/LeanplumSample/Assets/LeanplumSDK/LeanplumAndroid/LeanplumAndroid.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/LeanplumAndroid/LeanplumAndroid.cs
@@ -287,6 +287,17 @@ namespace LeanplumSDK
     }
 
     /// <summary>
+    ///     Logs a pruchase event in your application. The string can be any
+    ///     value of your choosing, however in most cases you will want to use
+    ///     Leanplum.PURCHASE_EVENT_NAME
+    /// </summary>
+    public override void TrackPurchase(string eventName, double value, string currencyCode,
+        IDictionary<string, object> parameters)
+    {
+      NativeSDK.CallStatic("trackPurchase", eventName, value, currencyCode, Json.Serialize(parameters));
+    }
+
+    /// <summary>
     ///     Logs a particular event in your application. The string can be
     ///     any value of your choosing, and will show up in the dashboard.
     ///     To track purchases, use Leanplum.PURCHASE_EVENT_NAME as the event name.

--- a/LeanplumSample/Assets/LeanplumSDK/LeanplumIOS/LeanplumIOS.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/LeanplumIOS/LeanplumIOS.cs
@@ -57,6 +57,10 @@ namespace LeanplumSDK
         internal static extern void _trackIOSInAppPurchases();
 
         [DllImport ("__Internal")]
+        internal static extern void _trackPurchase(string _event, double value, string currencyCode,
+          string dictStringJSON);
+
+        [DllImport ("__Internal")]
         internal static extern void _track(string _event, double value, string info,
           string dictStringJSON);
 
@@ -355,6 +359,18 @@ namespace LeanplumSDK
         public override void TrackIOSInAppPurchases()
         {
             _trackIOSInAppPurchases();
+        }
+
+        /// <summary>
+        ///     Logs a pruchase event in your application. The string can be any
+        ///     value of your choosing, however in most cases you will want to use
+        ///     Leanplum.PURCHASE_EVENT_NAME
+        /// </summary>
+        public override void TrackPurchase(string eventName, double value, string currencyCode,
+            IDictionary<string, object> parameters)
+        {
+            string parametersString = parameters == null ? null : Json.Serialize(parameters);
+            _trackPurchase(eventName, value, currencyCode, parametersString);
         }
 
         /// <summary>

--- a/LeanplumSample/Assets/LeanplumSDK/LeanplumNative/LeanplumNative.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/LeanplumNative/LeanplumNative.cs
@@ -628,6 +628,20 @@ namespace LeanplumSDK
         ///     any value of your choosing, and will show up in the dashboard.
         ///     To track purchases, use Leanplum.PURCHASE_EVENT_NAME as the event name.
         /// </summary>
+        public override void TrackPurchase(string eventName, double value, string currencyCode,
+            IDictionary<string, object> parameters)
+        {
+            IDictionary<string, string> arguments = new Dictionary<string, string>();
+            arguments["currencyCode"] = currencyCode;
+
+            Track(eventName, value, null, parameters, arguments);
+        }
+
+        /// <summary>
+        ///     Logs a particular event in your application. The string can be
+        ///     any value of your choosing, and will show up in the dashboard.
+        ///     To track purchases, use Leanplum.PURCHASE_EVENT_NAME as the event name.
+        /// </summary>
         public override void Track(string eventName, double value, string info,
             IDictionary<string, object> parameters)
         {

--- a/LeanplumSample/Assets/LeanplumSDK/LeanplumSDKObject.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/LeanplumSDKObject.cs
@@ -242,6 +242,14 @@ namespace LeanplumSDK
         }
 
         /// <summary>
+        ///     Logs a pruchase event in your application. The string can be any
+        ///     value of your choosing, however in most cases you will want to use
+        ///     Leanplum.PURCHASE_EVENT_NAME
+        /// </summary>
+        public abstract void TrackPurchase(string eventName, double value, string currencyCode,
+            IDictionary<string, object> parameters);
+
+        /// <summary>
         ///     Logs a particular event in your application. The string can be
         ///     any value of your choosing, and will show up in the dashboard.
         ///     To track purchases, use Leanplum.PURCHASE_EVENT_NAME as the event name.

--- a/LeanplumSample/Assets/Plugins/iOS/LeanplumIOSBridge.mm
+++ b/LeanplumSample/Assets/Plugins/iOS/LeanplumIOSBridge.mm
@@ -308,6 +308,17 @@ extern "C"
         [Leanplum trackInAppPurchases];
     }
 
+    void _trackPurchase(const char *event, double value, const char *currencyCode, const char *dictStringJSON)
+    {
+        NSData *data = [leanplum_createNSString(dictStringJSON) dataUsingEncoding:NSUTF8StringEncoding];
+        NSDictionary *dictionary = [NSJSONSerialization JSONObjectWithData:data
+                                                                   options:NSUTF8StringEncoding
+                                                                     error:nil];
+
+        [Leanplum trackPurchase:leanplum_createNSString(event) withValue:value andCurrencyCode:leanplum_createNSString(currencyCode)
+          andParameters:dictionary];
+    }
+
     void _track(const char *event, double value, const char *info, const char *dictStringJSON)
     {
         NSData *data = [leanplum_createNSString(dictStringJSON) dataUsingEncoding:NSUTF8StringEncoding];


### PR DESCRIPTION
exposed track purchase api for Unity implementations that cannot use the generic track all purchases setup