### PR TITLE
Fixed code signing issue on iOS

### DIFF
--- a/LeanplumSample/Assets/Plugins/iOS/Leanplum.framework.meta
+++ b/LeanplumSample/Assets/Plugins/iOS/Leanplum.framework.meta
@@ -107,7 +107,7 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        AddToEmbeddedBinaries: true
+        AddToEmbeddedBinaries: false
         CompileFlags: 
         FrameworkDependencies: Security;StoreKit;
   userData: 


### PR DESCRIPTION
We ran into a `Code signing "Leanplum.framework" failed.` error when building with automatic signing disabled. By disabling the "Add to Embedded Binaries" option, our builds started working again.
