### PR TITLE
Fixed warnings in the SDK

### DIFF
--- a/LeanplumSample/Assets/LeanplumSDK/Leanplum.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/Leanplum.cs
@@ -403,6 +403,7 @@ namespace LeanplumSDK
         /// <param name="dataSignature">Purchase data signature from
         /// com.android.vending.billing.util.Purchase.getSignature().</param>
         /// <param name="parameters">Optional event parameters.</param>
+        [Obsolete("TrackGooglePlayPurchase is obsolete. Please use TrackPurchase.")]
         public static void TrackGooglePlayPurchase(string item, long priceMicros,
             string currencyCode, string purchaseData, string dataSignature,
             IDictionary<string, object> parameters)
@@ -414,6 +415,7 @@ namespace LeanplumSDK
         /// <summary>
         ///     Automatically track in-app purchases on iOS.
         /// </summary>
+        [Obsolete("TrackIOSInAppPurchases is obsolete. Please use TrackPurchase.")]
         public static void TrackIOSInAppPurchases()
         {
             LeanplumFactory.SDK.TrackIOSInAppPurchases();
@@ -446,6 +448,7 @@ namespace LeanplumSDK
         /// <param name="parameters">
         ///     Optional event parameters.
         /// </param>
+        [Obsolete("TrackIOSInAppPurchase is obsolete. Please use TrackPurchase.")]
         public static void TrackIOSInAppPurchase(string item, double unitPrice, int quantity,
             string currencyCode, string transactionIdentifier, string receiptData,
             IDictionary<string, object> parameters)

--- a/LeanplumSample/Assets/LeanplumSDK/LeanplumAndroid/LeanplumAndroid.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/LeanplumAndroid/LeanplumAndroid.cs
@@ -292,7 +292,7 @@ namespace LeanplumSDK
         }
 
         /// <summary>
-        ///     Logs a pruchase event in your application. The string can be any
+        ///     Logs a purchase event in your application. The string can be any
         ///     value of your choosing, however in most cases you will want to use
         ///     Leanplum.PURCHASE_EVENT_NAME
         /// </summary>

--- a/LeanplumSample/Assets/LeanplumSDK/LeanplumIOS/LeanplumIOS.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/LeanplumIOS/LeanplumIOS.cs
@@ -377,6 +377,7 @@ namespace LeanplumSDK
             _defineAction(name, (int) kind, argString, optionString);
         }
 
+        [Obsolete("TrackIOSInAppPurchase is obsolete. Please use TrackPurchase.")]
         public override void TrackIOSInAppPurchases()
         {
             _trackIOSInAppPurchases();

--- a/LeanplumSample/Assets/LeanplumSDK/LeanplumIOS/LeanplumIOS.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/LeanplumIOS/LeanplumIOS.cs
@@ -384,7 +384,7 @@ namespace LeanplumSDK
         }
 
         /// <summary>
-        ///     Logs a pruchase event in your application. The string can be any
+        ///     Logs a purchase event in your application. The string can be any
         ///     value of your choosing, however in most cases you will want to use
         ///     Leanplum.PURCHASE_EVENT_NAME
         /// </summary>

--- a/LeanplumSample/Assets/LeanplumSDK/LeanplumNative/LeanplumNative.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/LeanplumNative/LeanplumNative.cs
@@ -575,6 +575,7 @@ namespace LeanplumSDK
 
         }
 
+        [Obsolete("TrackGooglePlayPurchase is obsolete. Please use TrackPurchase.")]
         public override void TrackGooglePlayPurchase(string item, long priceMicros,
             string currencyCode, string purchaseData, string dataSignature,
             IDictionary<string, object> parameters)
@@ -596,6 +597,7 @@ namespace LeanplumSDK
             Track(PURCHASE_EVENT_NAME, priceMicros / 1000000.0, null, modifiedParams, arguments);
         }
 
+        [Obsolete("TrackIOSInAppPurchase is obsolete. Please use TrackPurchase.")]
         public override void TrackIOSInAppPurchase(string item, double unitPrice, int quantity,
             string currencyCode, string transactionIdentifier, string receiptData,
             IDictionary<string, object> parameters)

--- a/LeanplumSample/Assets/LeanplumSDK/LeanplumNative/LeanplumNative.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/LeanplumNative/LeanplumNative.cs
@@ -476,7 +476,7 @@ namespace LeanplumSDK
             parameters[Constants.Params.DEVICE_SYSTEM_NAME] = CompatibilityLayer.GetSystemName();
             parameters[Constants.Params.DEVICE_SYSTEM_VERSION] =
                 CompatibilityLayer.GetSystemVersion();
-            TimeZone timezone = System.TimeZone.CurrentTimeZone;
+            var timezone = TimeZoneInfo.Local;
             if (timezone.IsDaylightSavingTime(DateTime.UtcNow))
             {
                 parameters[Constants.Keys.TIMEZONE] = timezone.DaylightName;

--- a/LeanplumSample/Assets/LeanplumSDK/LeanplumNative/UnityCompatibilityLayer.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/LeanplumNative/UnityCompatibilityLayer.cs
@@ -150,7 +150,7 @@ namespace LeanplumSDK
 
         public string URLEncode(string str)
         {
-            return WWW.EscapeURL(str, Encoding.UTF8);
+            return Uri.EscapeUriString(str);
         }
         #endregion Web
 

--- a/LeanplumSample/Assets/LeanplumSDK/LeanplumSDKObject.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/LeanplumSDKObject.cs
@@ -237,7 +237,7 @@ namespace LeanplumSDK
         }
 
         /// <summary>
-        ///     Logs a pruchase event in your application. The string can be any
+        ///     Logs a purchase event in your application. The string can be any
         ///     value of your choosing, however in most cases you will want to use
         ///     Leanplum.PURCHASE_EVENT_NAME
         /// </summary>

--- a/LeanplumSample/Assets/LeanplumSDK/LeanplumUnityHelper.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/LeanplumUnityHelper.cs
@@ -191,7 +191,7 @@ namespace LeanplumSDK
 #if LP_UNITYWEBREQUEST
             using (var request = CreateWebRequest(url, wwwForm, isAsset))
             {
-                var operation = request.Send();
+                var operation = request.SendWebRequest();
                 float elapsed = 0.0f;
                 while (!operation.isDone && elapsed < timeout)
                 {


### PR DESCRIPTION
We had several warnings in the SDK. Some were caused by the old track purchase methods being marked as obsolete, but those obsolete methods still being called and overridden. Adding the obsolete attribute to these overrides fixed those warnings.

We also had warnings due to old Unity and C# methods being called:
- ~~UnityWebRequest.SendWebRequest instead of UnityWebRequest.Send. The new method is supported by Unity 2017.2 and later, so all the currently publicly supported Unity versions.~~ Just got fixed on master.
- TimeZoneInfo.Local instead of TimeZone.CurrentTimeZone. I couldn't track down when Unity started supporting it, but it's been supported by .NET for the past 10 years.
- Uri.EscapeUriString instead of WWW.EscapeURL. Supported by .NET for the past 18 years.