### PR TITLE
Set calledStart in Test Mode

### DIFF
--- a/LeanplumSample/Assets/LeanplumSDK/LeanplumNative/LeanplumNative.cs
+++ b/LeanplumSample/Assets/LeanplumSDK/LeanplumNative/LeanplumNative.cs
@@ -414,6 +414,7 @@ namespace LeanplumSDK
             if (Constants.isNoop)
             {
                 _hasStarted = true;
+                calledStart = true;
                 startSuccessful = true;
                 OnVariablesChanged();
                 OnVariablesChangedAndNoDownloadsPending();


### PR DESCRIPTION
Without this, performing some actions like `SetUserAttributes` throws an error in test mode.