### PR TITLE
[SDK-202] Add set upload interval for Android

### DIFF
--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
@@ -102,6 +102,20 @@ public class UnityBridge {
     Leanplum.setNetworkTimeout(seconds, downloadSeconds);
   }
 
+  public static void setEventsUploadInterval(int uploadInterval) {
+    EventsUploadInterval interval = null;
+    for (EventsUploadInterval i : EventsUploadInterval.values()) {
+      if (i.getMinutes() == uploadInterval) {
+        interval = i;
+        break;
+      }
+    }
+    
+    if (interval != null) {
+      Leanplum.setEventsUploadInterval(interval);
+    }
+  }
+
   public static void setAppIdForDevelopmentMode(String appId, String accessKey) {
     isDeveloper = true;
     Leanplum.setAppIdForDevelopmentMode(appId, accessKey);

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
@@ -138,6 +138,11 @@ namespace LeanplumSDK
             NativeSDK.CallStatic("setNetworkTimeout", seconds, downloadSeconds);
         }
 
+        /// <summary>
+        ///     Sets the time interval between uploading events to server.
+        ///     Default is <see cref="EventsUploadInterval.AtMost15Minutes"/>.
+        /// </summary>
+        /// <param name="uploadInterval"> The time between uploads. </param>
         public override void SetEventsUploadInterval(EventsUploadInterval uploadInterval)
         {
             NativeSDK.CallStatic("setEventsUploadInterval", (int)uploadInterval);

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
@@ -74,7 +74,7 @@ namespace LeanplumSDK
             nativeSdk = new AndroidJavaClass("com.leanplum.UnityBridge");
         }
 
-        #region Accessors and Mutators
+#region Accessors and Mutators
         /// <summary>
         ///     Gets a value indicating whether Leanplum has finished starting.
         /// </summary>
@@ -136,6 +136,11 @@ namespace LeanplumSDK
         public override void SetNetworkTimeout(int seconds, int downloadSeconds)
         {
             NativeSDK.CallStatic("setNetworkTimeout", seconds, downloadSeconds);
+        }
+
+        public override void SetEventsUploadInterval(EventsUploadInterval uploadInterval)
+        {
+            NativeSDK.CallStatic("setEventsUploadInterval", (int)uploadInterval);
         }
 
         /// <summary>
@@ -282,9 +287,9 @@ namespace LeanplumSDK
         {
             NativeSDK.CallStatic("disableLocationCollection");
         }
-        #endregion
+#endregion
 
-        #region API Calls
+#region API Calls
 
         /// <summary>
         ///     Call this when your application starts.
@@ -437,7 +442,7 @@ namespace LeanplumSDK
             NativeSDK.CallStatic("forceContentUpdateWithCallback", key);
         }
 
-        #endregion
+#endregion
 
         public override void NativeCallback(string message)
         {
@@ -498,7 +503,7 @@ namespace LeanplumSDK
             }
         }
 
-        #region Dealing with Variables
+#region Dealing with Variables
 
         protected static IDictionary<string, Var> AndroidVarCache = new Dictionary<string, Var>();
 
@@ -609,7 +614,7 @@ namespace LeanplumSDK
             }
         }
 
-        #endregion
+#endregion
 
     }
 }

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
@@ -74,7 +74,7 @@ namespace LeanplumSDK
             nativeSdk = new AndroidJavaClass("com.leanplum.UnityBridge");
         }
 
-#region Accessors and Mutators
+        #region Accessors and Mutators
         /// <summary>
         ///     Gets a value indicating whether Leanplum has finished starting.
         /// </summary>
@@ -287,9 +287,9 @@ namespace LeanplumSDK
         {
             NativeSDK.CallStatic("disableLocationCollection");
         }
-#endregion
+        #endregion
 
-#region API Calls
+        #region API Calls
 
         /// <summary>
         ///     Call this when your application starts.
@@ -442,7 +442,7 @@ namespace LeanplumSDK
             NativeSDK.CallStatic("forceContentUpdateWithCallback", key);
         }
 
-#endregion
+        #endregion
 
         public override void NativeCallback(string message)
         {
@@ -503,7 +503,7 @@ namespace LeanplumSDK
             }
         }
 
-#region Dealing with Variables
+        #region Dealing with Variables
 
         protected static IDictionary<string, Var> AndroidVarCache = new Dictionary<string, Var>();
 
@@ -614,7 +614,7 @@ namespace LeanplumSDK
             }
         }
 
-#endregion
+        #endregion
 
     }
 }

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
@@ -161,7 +161,7 @@ namespace LeanplumSDK
 
         static private int DictionaryKey = 0;
 
-        #region Accessors and Mutators
+#region Accessors and Mutators
 
         public override void RegisterForIOSRemoteNotifications()
         {
@@ -232,6 +232,11 @@ namespace LeanplumSDK
         public override void SetNetworkTimeout(int seconds, int downloadSeconds)
         {
             _setNetworkTimeout(seconds, downloadSeconds);
+        }
+
+        public override void SetEventsUploadInterval(EventsUploadInterval uploadInterval)
+        {
+            
         }
 
         /// <summary>
@@ -381,9 +386,9 @@ namespace LeanplumSDK
         {
           _disableLocationCollection();
         }
-        #endregion
+#endregion
 
-        #region API Calls
+#region API Calls
 
         /// <summary>
         ///     Call this when your application starts.
@@ -544,7 +549,7 @@ namespace LeanplumSDK
             _forceContentUpdateWithCallback(key);
         }
 
-        #endregion
+#endregion
 
         public override void NativeCallback(string message)
         {
@@ -605,7 +610,7 @@ namespace LeanplumSDK
             }
         }
 
-        #region Dealing with Variables
+#region Dealing with Variables
 
         [DllImport ("__Internal")]
         internal static extern void _defineVariable(string name, string kind, string jsonValue);
@@ -777,7 +782,7 @@ namespace LeanplumSDK
             }
         }
 
-        #endregion
+#endregion
     }
 }
 

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
@@ -161,7 +161,7 @@ namespace LeanplumSDK
 
         static private int DictionaryKey = 0;
 
-#region Accessors and Mutators
+        #region Accessors and Mutators
 
         public override void RegisterForIOSRemoteNotifications()
         {
@@ -386,9 +386,9 @@ namespace LeanplumSDK
         {
           _disableLocationCollection();
         }
-#endregion
+        #endregion
 
-#region API Calls
+        #region API Calls
 
         /// <summary>
         ///     Call this when your application starts.
@@ -549,7 +549,7 @@ namespace LeanplumSDK
             _forceContentUpdateWithCallback(key);
         }
 
-#endregion
+        #endregion
 
         public override void NativeCallback(string message)
         {
@@ -610,7 +610,7 @@ namespace LeanplumSDK
             }
         }
 
-#region Dealing with Variables
+        #region Dealing with Variables
 
         [DllImport ("__Internal")]
         internal static extern void _defineVariable(string name, string kind, string jsonValue);
@@ -782,7 +782,7 @@ namespace LeanplumSDK
             }
         }
 
-#endregion
+        #endregion
     }
 }
 

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/EventsUploadInterval.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/EventsUploadInterval.cs
@@ -1,14 +1,24 @@
 ﻿namespace LeanplumSDK
 {
+    /// <summary>
+    ///     Represents time interval to periodically upload events to server.
+    ///     Possible values are 5, 10, or 15 minutes.
+    /// </summary>
     public enum EventsUploadInterval
     {
-        // 5 minutes interval
+        /// <summary>
+        ///     5 minutes interval
+        /// </summary>
         AtMost5Minutes = 5,
 
-        // 10 minutes interval
+        /// <summary>
+        ///     10 minutes interval
+        /// </summary>
         AtMost10Minutes = 10,
 
-        // 15 minutes interval
-        AtMost15Minutes = 15,
+        /// <summary>
+        ///     15 minutes interval
+        /// </summary>
+        AtMost15Minutes = 15
     }
 }

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/EventsUploadInterval.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/EventsUploadInterval.cs
@@ -1,0 +1,14 @@
+﻿namespace LeanplumSDK
+{
+    public enum EventsUploadInterval
+    {
+        // 5 minutes interval
+        AtMost5Minutes = 5,
+
+        // 10 minutes interval
+        AtMost10Minutes = 10,
+
+        // 15 minutes interval
+        AtMost15Minutes = 15,
+    }
+}

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/EventsUploadInterval.cs.meta
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/EventsUploadInterval.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d80545b9d3a2b4fff9108d665ca2c2bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Leanplum.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Leanplum.cs
@@ -115,6 +115,11 @@ namespace LeanplumSDK
             LeanplumFactory.SDK.SetNetworkTimeout(seconds, downloadSeconds);
         }
 
+        public static void SetEventsUploadInterval(EventsUploadInterval uploadInterval)
+        {
+            LeanplumFactory.SDK.SetEventsUploadInterval(uploadInterval);
+        }
+
         /// <summary>
         ///     Must call either this or SetAppIdForProductionMode
         ///     before issuing any calls to the API, including start.

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Leanplum.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Leanplum.cs
@@ -115,6 +115,11 @@ namespace LeanplumSDK
             LeanplumFactory.SDK.SetNetworkTimeout(seconds, downloadSeconds);
         }
 
+        /// <summary>
+        ///     Sets the time interval between uploading events to server.
+        ///     Default is <see cref="EventsUploadInterval.AtMost15Minutes"/>.
+        /// </summary>
+        /// <param name="uploadInterval"> The time between uploads. </param>
         public static void SetEventsUploadInterval(EventsUploadInterval uploadInterval)
         {
             LeanplumFactory.SDK.SetEventsUploadInterval(uploadInterval);

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSDKObject.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSDKObject.cs
@@ -82,6 +82,11 @@ namespace LeanplumSDK
         /// <param name="downloadSeconds"> Timeout in seconds for downloads. </param>
         public abstract void SetNetworkTimeout (int seconds, int downloadSeconds);
 
+        /// <summary>
+        ///     Sets the time interval between uploading events to server.
+        ///     Default is <see cref="EventsUploadInterval.AtMost15Minutes"/>.
+        /// </summary>
+        /// <param name="uploadInterval"> The time between uploads. </param>
         public abstract void SetEventsUploadInterval(EventsUploadInterval uploadInterval);
 
         /// <summary>

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSDKObject.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSDKObject.cs
@@ -82,6 +82,8 @@ namespace LeanplumSDK
         /// <param name="downloadSeconds"> Timeout in seconds for downloads. </param>
         public abstract void SetNetworkTimeout (int seconds, int downloadSeconds);
 
+        public abstract void SetEventsUploadInterval(EventsUploadInterval uploadInterval);
+
         /// <summary>
         ///     Must call either this or SetAppIdForProductionMode
         ///     before issuing any calls to the API, including start.

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
@@ -160,6 +160,12 @@ namespace LeanplumSDK
             Constants.NETWORK_TIMEOUT_SECONDS_FOR_DOWNLOADS = downloadSeconds;
         }
 
+        /// <summary>
+        ///     Sets the time interval between uploading events to server.
+        ///     Default is <see cref="EventsUploadInterval.AtMost15Minutes"/>.
+        ///     Not supported on Unity.
+        /// </summary>
+        /// <param name="uploadInterval"> The time between uploads. </param>
         public override void SetEventsUploadInterval(EventsUploadInterval uploadInterval)
         {
 

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
@@ -160,6 +160,11 @@ namespace LeanplumSDK
             Constants.NETWORK_TIMEOUT_SECONDS_FOR_DOWNLOADS = downloadSeconds;
         }
 
+        public override void SetEventsUploadInterval(EventsUploadInterval uploadInterval)
+        {
+
+        }
+
         /// <summary>
         ///     Must call either this or SetAppIdForProductionMode
         ///     before issuing any calls to the API, including start.


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-202](https://leanplum.atlassian.net/browse/SDK-202)

## Background
Adds the option to set the upload interval from Unity. Supported on iOS and Android only.
[Android PR](https://github.com/Leanplum/Leanplum-Android-SDK/pull/428/files)

## Implementation

## Testing steps

## Is this change backwards-compatible?
