### PR TITLE
[SDK-226] Fix double and long deserialization

### DIFF
--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Utilities/MiniJSON.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Utilities/MiniJSON.cs
@@ -291,14 +291,20 @@ namespace LeanplumSDK.MiniJSON {
             object ParseNumber() {
                 string number = NextWord;
 
-                if (number.IndexOf('.') == -1) {
+                if (number.IndexOf('.') == -1 && number.IndexOf("E-") == -1 && number.IndexOf("e-") == -1) {
                     long parsedInt;
-                    Int64.TryParse(number, out parsedInt);
+                    Int64.TryParse(number, NumberStyles.Any, CultureInfo.InvariantCulture, out parsedInt);
+                    if (parsedInt == 0)
+                    {
+                        ulong parsedUInt;
+                        UInt64.TryParse(number, NumberStyles.Any, CultureInfo.InvariantCulture, out parsedUInt);
+                        return parsedUInt;
+                    }
                     return parsedInt;
                 }
 
                 double parsedDouble;
-                Double.TryParse(number, out parsedDouble);
+                Double.TryParse(number, NumberStyles.Any, CultureInfo.InvariantCulture, out parsedDouble);
                 return parsedDouble;
             }
 


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-226](https://leanplum.atlassian.net/browse/SDK-226)

## Background
Double and long serialization/deserialization does not work correctly.

## Implementation

## Testing steps
Tested using the following values:
```csharp   
        ulong n = 12156480978394720353;
        double d = 0.000000001;
        decimal dc = 5.6789012345678901234567890123456789012345M;
        var currentCul = CultureInfo.CurrentCulture;
        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("DE");
        var dict = new Dictionary<string, object> { { "d", d }, { "l", n }, { "ll",  0}, { "dd", 0.12 }, { "dc", dc } };
        var test = Json.Serialize(dict);
        dict = Json.Deserialize(test) as Dictionary<string, object>;
```

## Is this change backwards-compatible?
