### PR TITLE
[SDK-224] Add iOS setEventsUploadInterval

### DIFF
--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
@@ -72,6 +72,9 @@ namespace LeanplumSDK
         [DllImport ("__Internal")]
         internal static extern void _setNetworkTimeout(int seconds, int downloadSeconds);
 
+        [DllImport("__Internal")]
+        internal static extern void _setEventsUploadInterval(int uploadInterval);
+
         [DllImport ("__Internal")]
         internal static extern void _setAppVersion(string version);
 
@@ -242,9 +245,14 @@ namespace LeanplumSDK
             _setNetworkTimeout(seconds, downloadSeconds);
         }
 
+        /// <summary>
+        ///     Sets the time interval between uploading events to server.
+        ///     Default is <see cref="EventsUploadInterval.AtMost15Minutes"/>.
+        /// </summary>
+        /// <param name="uploadInterval"> The time between uploads. </param>
         public override void SetEventsUploadInterval(EventsUploadInterval uploadInterval)
         {
-            
+            _setEventsUploadInterval((int)uploadInterval);
         }
 
         /// <summary>

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
@@ -106,6 +106,14 @@ extern "C"
         [Leanplum setNetworkTimeoutSeconds:seconds forDownloads:downloadSeconds];
     }
 
+    void _setEventsUploadInterval(int uploadInterval)
+    {
+        LPEventsUploadInterval interval = (LPEventsUploadInterval)uploadInterval;
+        if (interval == AT_MOST_5_MINUTES || interval == AT_MOST_10_MINUTES || interval == AT_MOST_15_MINUTES) {
+            [Leanplum setEventsUploadInterval:interval];
+        }
+    }
+
     void _setAppVersion(const char *version)
     {
         [Leanplum setAppVersion:lp::to_nsstring(version)];


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-224](https://leanplum.atlassian.net/browse/SDK-224)

## Background
Adds the option to set the upload interval from Unity on iOS.
[iOS PR](https://github.com/Leanplum/Leanplum-iOS-SDK/pull/413)

## Implementation

## Testing steps

## Is this change backwards-compatible?
