### PR TITLE
[SDK-266] Add Inbox DownloadMessages

### DIFF
--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/build.gradle
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/build.gradle
@@ -36,7 +36,7 @@ task copyAAR(type: Copy) {
     duplicatesStrategy = DuplicatesStrategy.WARN
 
     from('build/outputs/aar')
-    into('../../LeanplumSample/Assets/Plugins/Android')
+    into('../../Leanplum-Unity-SDK/Assets/Plugins/Android')
     def name = project.name + '-release.aar'
     include(name)
     rename(name, 'com.leanplum.unity-wrapper-' + LP_VERSION +'.aar')

--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
@@ -389,6 +389,20 @@ public class UnityBridge {
     return gson.toJson(Leanplum.getInbox().messagesIds());
   }
 
+  public static void downloadMessages() {
+    Leanplum.getInbox().downloadMessages();
+  }
+
+  public static void downloadMessagesWithCallback() {
+    Leanplum.getInbox().downloadMessages(new InboxSyncedCallback() {
+      @Override
+      public void onForceContentUpdate(boolean success) {
+        int result = success ? 1 : 0;
+        makeCallbackToUnity("InboxDownloadMessages:" + result);
+      }
+    });
+  }
+
   public static String inboxMessages() {
     String pattern = "yyyy-MM-dd'T'HH:mm:ssZZZZZ";
     SimpleDateFormat formatter = new SimpleDateFormat(pattern);

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumInboxAndroid.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumInboxAndroid.cs
@@ -13,6 +13,8 @@ namespace LeanplumSDK
         public override event OnInboxChanged InboxChanged;
         public override event OnForceContentUpdate ForceContentUpdate;
 
+        public event OnForceContentUpdate OneTimeUpdate;
+
         private AndroidJavaClass nativeSdk = null;
 
         internal LeanplumInboxAndroid(AndroidJavaClass native)
@@ -63,6 +65,18 @@ namespace LeanplumSDK
                 }).ToList();
             }
         }
+
+        public override void DownloadMessages()
+        {
+            nativeSdk.CallStatic("downloadMessages");
+        }
+
+        public override void DownloadMessages(OnForceContentUpdate completedHandler)
+        {
+            OneTimeUpdate = completedHandler;
+            nativeSdk.CallStatic("downloadMessagesWithCallback");
+        }
+
         public override void Read(string messageId)
         {
             if (messageId != null)
@@ -128,6 +142,12 @@ namespace LeanplumSDK
             {
                 bool success = message.EndsWith("1");
                 ForceContentUpdate?.Invoke(success);
+            }
+            else if (message.StartsWith("InboxDownloadMessages:"))
+            {
+                bool success = message.EndsWith("1");
+                OneTimeUpdate?.Invoke(success);
+                OneTimeUpdate = null;
             }
         }
 

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumInbox.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumInbox.cs
@@ -155,7 +155,15 @@ namespace LeanplumSDK
             });
         }
 
+        /// <summary>
+        /// Forces downloading of inbox messages from the server. After messages are downloaded the appropriate callbacks will fire.
+        /// </summary>
         public abstract void DownloadMessages();
+
+        /// <summary>
+        /// Forces downloading of inbox messages from the server. After messages are downloaded the appropriate callbacks will fire.
+        /// </summary>
+        /// <param name="completedHandler">The callback to invoke when messages are downloaded.</param>
         public abstract void DownloadMessages(OnForceContentUpdate completedHandler);
 
         /// <summary>

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumInbox.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumInbox.cs
@@ -155,6 +155,9 @@ namespace LeanplumSDK
             });
         }
 
+        public abstract void DownloadMessages();
+        public abstract void DownloadMessages(OnForceContentUpdate completedHandler);
+
         /// <summary>
         /// Read the inbox message, marking it as read and invoking its open action.
         /// </summary>

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
@@ -507,6 +507,20 @@ extern "C"
         return lp::to_json_string([Leanplum inbox].messagesIds);
     }
 
+    void _inbox_downloadMessages()
+    {
+        [[Leanplum inbox] downloadMessages];
+    }
+
+    void _inbox_downloadMessagesWithCallback()
+    {
+        [[Leanplum inbox] downloadMessages:^(BOOL success) {
+            int res = [@(success) intValue];
+            UnitySendMessage(__LPgameObject, "NativeCallback",
+                                 [[NSString stringWithFormat:@"InboxDownloadMessages:%d", res] UTF8String]);
+        }];
+    }
+
     const char *_inbox_messages()
     {
         NSMutableArray<NSDictionary *> *messageData = [NSMutableArray new];


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-266](https://leanplum.atlassian.net/browse/SDK-266)

## Background
Implement the Inbox DownloadMessage methods available in the native iOS and Android SDKs (3.1.1 and 5.5.0).

## Implementation
Implement the method in the Leanplum Native Inbox, iOS and Android.
Use the native callbacks to communicate.

## Testing steps

## Is this change backwards-compatible?
