### PR TITLE
Action context fixes

### DIFF
--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityActionContextBridge.java
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityActionContextBridge.java
@@ -1,7 +1,10 @@
 package com.leanplum;
 
+import android.graphics.Color;
+
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import com.leanplum.internal.FileManager;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -135,6 +138,30 @@ public class UnityActionContextBridge {
             }
         }
         return null;
+    }
+
+    public static int getColorNamed(String contextId, String name) {
+        ActionContext context = actionContexts.get(contextId);
+        if (context != null) {
+            Number n = context.numberNamed(name);
+            if (n != null) {
+                return n.intValue();
+            }
+        }
+        return Color.BLACK;
+    }
+
+    public static String getFileNamed(String contextId, String name) {
+        ActionContext context = actionContexts.get(contextId);
+        String empty = "";
+        if (context != null) {
+            String stringValue = context.stringNamed(name);
+            if (stringValue == null || stringValue.length() == 0) {
+                return empty;
+            }
+            return FileManager.fileValue(stringValue);
+        }
+        return empty;
     }
 
     public static void muteFutureMessagesOfSameKind(String contextId) {

--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
@@ -271,7 +271,7 @@ public class UnityBridge {
         String argKind = (String) dict.get("kind");
         Object defaultValue = dict.get("defaultValue");
 
-        if (argName == null || argKind == null || defaultValue == null) {
+        if (argName == null || argKind == null || (defaultValue == null && !argKind.equals("action"))) {
           continue;
         }
 
@@ -290,8 +290,14 @@ public class UnityBridge {
         } else if (argKind.equals("action")) {
           if (defaultValue instanceof String) {
             actionArgs.withAction(argName, (String) defaultValue);
+          } else if (defaultValue == null) {
+            actionArgs.withAction(argName, null);
           }
         } else if (argKind.equals("color")) {
+          // defaultValue can come as a double with E7 notation
+          if (defaultValue instanceof Double) {
+            defaultValue = ((Double) defaultValue).intValue();
+          }
           if (defaultValue instanceof Integer) {
             actionArgs.withColor(argName, (int) defaultValue);
           }

--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
@@ -302,6 +302,9 @@ public class UnityBridge {
             actionArgs.withColor(argName, (int) defaultValue);
           }
         }
+        else if (argKind.equals("file")) {
+            actionArgs.withFile(name, (String) defaultValue);
+        }
       }
     }
 

--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
@@ -303,7 +303,7 @@ public class UnityBridge {
           }
         }
         else if (argKind.equals("file")) {
-            actionArgs.withFile(name, (String) defaultValue);
+            actionArgs.withFile(argName, (String) defaultValue);
         }
       }
     }

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/ActionContext.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/ActionContext.cs
@@ -71,6 +71,14 @@ namespace LeanplumSDK
         public abstract UnityEngine.Color GetColorNamed(string name);
 
         /// <summary>
+        /// Get file path for name.
+        /// Returns URL on Unity. Returns file path on iOS and Android.
+        /// </summary>
+        /// <param name="name">name of the file argument</param>
+        /// <returns></returns>
+        public abstract string GetFile(string name);
+
+        /// <summary>
         /// Get number for name
         /// </summary>
         /// <param name="name">name of the number</param>

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/ActionContext.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/ActionContext.cs
@@ -64,6 +64,13 @@ namespace LeanplumSDK
         public abstract T GetObjectNamed<T>(string name);
 
         /// <summary>
+        /// Get UnityEngine Color for name
+        /// </summary>
+        /// <param name="name">name of the color</param>
+        /// <returns>found Color or default Color</returns>
+        public abstract UnityEngine.Color GetColorNamed(string name);
+
+        /// <summary>
         /// Get number for name
         /// </summary>
         /// <param name="name">name of the number</param>

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/ActionContextAndroid.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/ActionContextAndroid.cs
@@ -62,6 +62,12 @@ namespace LeanplumSDK
             return default(T);
         }
 
+        public override Color GetColorNamed(string name)
+        {
+            int intColor = GetNumberNamed<int>(name);
+            return Util.IntToColor(intColor);
+        }
+
         public override T GetNumberNamed<T>(string name)
         {
             Type t = typeof(T);

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/ActionContextAndroid.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/ActionContextAndroid.cs
@@ -68,6 +68,11 @@ namespace LeanplumSDK
             return Util.IntToColor(intColor);
         }
 
+        public override string GetFile(string name)
+        {
+            return nativeHandle.CallStatic<string>("getFileNamed", Name, name);
+        }
+
         public override T GetNumberNamed<T>(string name)
         {
             Type t = typeof(T);

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/ActionContextApple.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/ActionContextApple.cs
@@ -37,6 +37,9 @@ namespace LeanplumSDK.Apple
         internal static extern bool get_bool_named(string id, string name);
 
         [DllImport("__Internal")]
+        internal static extern long get_color_named(string id, string name);
+
+        [DllImport("__Internal")]
         internal static extern string get_dictionary_named(string id, string name);
 
         [DllImport("__Internal")]
@@ -118,6 +121,12 @@ namespace LeanplumSDK.Apple
             }
 
             return default(T);
+        }
+
+        public override UnityEngine.Color GetColorNamed(string name)
+        {
+            long color = get_color_named(Name, name);
+            return Util.IntToColor(color);
         }
 
         public override T GetNumberNamed<T>(string name)

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/ActionContextApple.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/ActionContextApple.cs
@@ -40,6 +40,9 @@ namespace LeanplumSDK.Apple
         internal static extern long get_color_named(string id, string name);
 
         [DllImport("__Internal")]
+        internal static extern string get_file_named(string id, string name);
+
+        [DllImport("__Internal")]
         internal static extern string get_dictionary_named(string id, string name);
 
         [DllImport("__Internal")]
@@ -127,6 +130,11 @@ namespace LeanplumSDK.Apple
         {
             long color = get_color_named(Name, name);
             return Util.IntToColor(color);
+        }
+
+        public override string GetFile(string name)
+        {
+            return get_file_named(Name, name);
         }
 
         public override T GetNumberNamed<T>(string name)

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/ActionArgs.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/ActionArgs.cs
@@ -69,6 +69,11 @@ namespace LeanplumSDK
             return ArgumentNamed(name, defaultValue, Constants.Kinds.COLOR);
         }
 
+        public static ActionArg<T> FileArgumentNamed(string name, T defaultValue)
+        {
+            return ArgumentNamed(name, defaultValue, Constants.Kinds.FILE);
+        }
+
         public static ActionArg<T> ActionArgumentNamed(string name, T defaultValue)
         {
             return ArgumentNamed(name, defaultValue, Constants.Kinds.ACTION);
@@ -110,6 +115,16 @@ namespace LeanplumSDK
 
             long value = Util.ColorToInt(defaultValue);
             args.Add(ActionArg<long>.ColorArgumentNamed(name, value));
+            return this;
+        }
+
+        public ActionArgs WithFile(string name)
+        {
+            if (name == null)
+            {
+                return this;
+            }
+            args.Add(ActionArg<string>.FileArgumentNamed(name, string.Empty));
             return this;
         }
 

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/ActionArgs.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/ActionArgs.cs
@@ -101,13 +101,15 @@ namespace LeanplumSDK
             return this;
         }
 
-        public ActionArgs WithColor<T>(string name, T defaultValue)
+        public ActionArgs WithColor(string name, UnityEngine.Color defaultValue)
         {
             if (name == null)
             {
                 return this;
             }
-            args.Add(ActionArg<T>.ColorArgumentNamed(name, defaultValue));
+
+            long value = Util.ColorToInt(defaultValue);
+            args.Add(ActionArg<long>.ColorArgumentNamed(name, value));
             return this;
         }
 

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/NativeActionContext.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/NativeActionContext.cs
@@ -105,6 +105,11 @@ namespace LeanplumSDK
             return new UnityEngine.Color();
         }
 
+        public override string GetFile(string name)
+        {
+            return GetFileURL(name);
+        }
+
         public override string GetStringNamed(string name)
         {
             var value = Traverse(name);

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/NativeActionContext.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/NativeActionContext.cs
@@ -80,8 +80,11 @@ namespace LeanplumSDK
 
             try
             {
-                // Collections come with elements of type object
-                return Util.ConvertCollectionToType<T>(value);
+                if (value is IDictionary || value is IList)
+                {
+                    // Collections come with elements of type object
+                    return Util.ConvertCollectionToType<T>(value);
+                }
             }
             catch (Exception ex)
             {
@@ -89,6 +92,17 @@ namespace LeanplumSDK
             }
 
             return (T)value;
+        }
+
+        public override UnityEngine.Color GetColorNamed(string name)
+        {
+            var value = Traverse(name);
+            if (value is long && value != null)
+            {
+                var colorVal = (long)value;
+                return Util.IntToColor(colorVal);
+            }
+            return new UnityEngine.Color();
         }
 
         public override string GetStringNamed(string name)

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/Utilities/Util.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/Utilities/Util.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using LeanplumSDK.MiniJSON;
+using UnityEngine;
 
 namespace LeanplumSDK
 {
@@ -317,6 +318,24 @@ namespace LeanplumSDK
             }
 
             return (T)collection;
+        }
+
+        internal static long ColorToInt(Color32 color32)
+        {
+            long color = (color32.a & 0xff) << 24 | (color32.r & 0xff) << 16 | (color32.g & 0xff) << 8 | (color32.b & 0xff);
+            return color;
+        }
+
+        internal static Color IntToColor(long colorVal)
+        {
+            Color32 c = new Color32
+            {
+                b = (byte)((colorVal) & 0xFF),
+                g = (byte)((colorVal >> 8) & 0xFF),
+                r = (byte)((colorVal >> 16) & 0xFF),
+                a = (byte)((colorVal >> 24) & 0xFF)
+            };
+            return c;
         }
 
         internal static bool IsNumber(object value)

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumActionContextBridge.mm
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumActionContextBridge.mm
@@ -100,6 +100,12 @@ long get_color_named(const char *contextId, const char *name)
     return intVal;
 }
 
+char * get_file_named(const char *contextId, const char *name)
+{
+    LPActionContext *context = [actionContexts objectForKey:lp::to_nsstring(contextId)];
+    return lp::to_string([context fileNamed:lp::to_nsstring(name)]);
+}
+
 char *get_dictionary_named(const char *contextId, const char *name)
 {
     LPActionContext *context = [actionContexts objectForKey:lp::to_nsstring(contextId)];

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumActionContextBridge.mm
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumActionContextBridge.mm
@@ -92,6 +92,14 @@ bool get_bool_named(const char *contextId, const char *name)
     return [context boolNamed:lp::to_nsstring(name)];
 }
 
+long get_color_named(const char *contextId, const char *name)
+{
+    LPActionContext *context = [actionContexts objectForKey:lp::to_nsstring(contextId)];
+    UIColor *color = [context colorNamed:lp::to_nsstring(name)];
+    long intVal = lp::leanplum_colorToInt(color);
+    return intVal;
+}
+
 char *get_dictionary_named(const char *contextId, const char *name)
 {
     LPActionContext *context = [actionContexts objectForKey:lp::to_nsstring(contextId)];

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
@@ -404,7 +404,7 @@ extern "C"
             else if ([argKind isEqualToString:LP_KIND_COLOR])
             {
                 long long longVal = [defaultValue longLongValue];
-                [arguments addObject:[LPActionArg argNamed:argName withColor:leanplum_intToColor(longVal)]];
+                [arguments addObject:[LPActionArg argNamed:argName withColor:lp::leanplum_intToColor(longVal)]];
             }
         }
 

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
@@ -350,6 +350,7 @@ extern "C"
         static NSString *LP_KIND_ARRAY = @"list";
         static NSString *LP_KIND_ACTION = @"action";
         static NSString *LP_KIND_COLOR = @"color";
+        static NSString *LP_KIND_FILE = @"file";
         
         for (NSDictionary* arg in argsArray)
         {
@@ -405,6 +406,10 @@ extern "C"
             {
                 long long longVal = [defaultValue longLongValue];
                 [arguments addObject:[LPActionArg argNamed:argName withColor:lp::leanplum_intToColor(longVal)]];
+            }
+            else if ([argKind isEqualToString:LP_KIND_FILE])
+            {
+                [arguments addObject:[LPActionArg argNamed:argName withFile:defaultValue]];
             }
         }
 

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
@@ -357,14 +357,20 @@ extern "C"
             NSString* argKind = arg[@"kind"];
             id defaultValue = arg[@"defaultValue"];
             
-            if (argName == nil || argKind == nil || defaultValue == nil)
+            if (argName == nil || argKind == nil || (defaultValue == nil && ![argKind isEqualToString:LP_KIND_ACTION]))
             {
                 continue;
             }
             
-            if ([argKind isEqualToString:LP_KIND_ACTION] && [defaultValue isKindOfClass:[NSString class]])
+            if ([argKind isEqualToString:LP_KIND_ACTION])
             {
+                // Allow registering an Action with null default value
+                // as it is done in the iOS SDK
                 NSString* actionValue = (NSString*) defaultValue;
+                if ([actionValue isKindOfClass:[NSNull class]])
+                {
+                    actionValue = nil;
+                }
                 [arguments addObject:[LPActionArg argNamed:argName withAction:actionValue]];
             }
             else if ([argKind isEqualToString:LP_KIND_INT] && [defaultValue isKindOfClass:[NSNumber class]])
@@ -394,6 +400,11 @@ extern "C"
             else if ([argKind isEqualToString:LP_KIND_ARRAY])
             {
                 [arguments addObject:[LPActionArg argNamed:argName withArray:defaultValue]];
+            }
+            else if ([argKind isEqualToString:LP_KIND_COLOR])
+            {
+                long long longVal = [defaultValue longLongValue];
+                [arguments addObject:[LPActionArg argNamed:argName withColor:leanplum_intToColor(longVal)]];
             }
         }
 

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumUnityHelper.h
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumUnityHelper.h
@@ -28,4 +28,8 @@ namespace lp
     NSString *to_nsstring(const char *str);
     char *to_string(NSString *str);
     char *to_json_string(id obj);
+
+    // Copied from the iOS SDK otherwise cannot be linked
+    long long leanplum_colorToInt(UIColor *value);
+    UIColor *leanplum_intToColor(long long value);
 }

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumUnityHelper.mm
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumUnityHelper.mm
@@ -60,4 +60,32 @@ namespace lp
                                                      encoding:NSUTF8StringEncoding];
         return copy_string([jsonString UTF8String]);
     }
+
+    long long leanplum_colorToInt(UIColor *value)
+    {
+        if (value == nil) {
+            return 0;
+        }
+        const CGFloat *components = CGColorGetComponents(value.CGColor);
+        if (CGColorGetNumberOfComponents(value.CGColor) < 4) {
+            NSUInteger w = (NSUInteger)(255 * components[0]);
+            NSUInteger a = (NSUInteger)(255 * components[1]);
+            return (a << 24) + (w << 16) + (w << 8) + w;
+        } else {
+            NSUInteger r = (NSUInteger)(255 * components[0]);
+            NSUInteger g = (NSUInteger)(255 * components[1]);
+            NSUInteger b = (NSUInteger)(255 * components[2]);
+            NSUInteger a = (NSUInteger)(255 * components[3]);
+            return (a << 24) + (r << 16) + (g << 8) + b;
+        }
+    }
+
+    UIColor *leanplum_intToColor(long long value)
+    {
+        int b = value & 0xFF;
+        int g = (value >> 8) & 0XFF;
+        int r = (value >> 16) & 0XFF;
+        int a = (value >> 24) & 0XFF;
+        return [UIColor colorWithRed:r / 255.0 green:g / 255.0 blue:b / 255.0   alpha:a / 255.0];
+    }
 }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-287](https://leanplum.atlassian.net/browse/SDK-287)

Fix definition of Actions - allow null as defaultValue. This will provide parity between Unity and iOS/Android.

Enable defining Colors. Use int as the color type (Android Color) and convert to the correct types on each platform.

Enable defining Files. Return the file path or URL.

## Background

Add support for Color and Files.

## Implementation

Use integer/long to pass the Color values between Unity and iOS/Android.

Implement registering Files and getting the file from the Action Context.
Returns asset URL (download URL from LP) on Unity Native/Editor.
Returns file path (file://) on Android and iOS.

## Testing steps

## Is this change backwards-compatible?
