### PR TITLE
[SDK-293] Implement Native Inbox Open Action

### DIFF
--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/VarCache.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/VarCache.cs
@@ -396,6 +396,14 @@ namespace LeanplumSDK
                             var messageConfig = Util.GetValueOrDefault(values, Constants.Args.VARS) as Dictionary<string, object>;
                             if (messageConfig != null)
                             {
+                                // Merges the default argument values defined in the Action Definition with the values coming from the API.
+                                // The API returns only the modified values from the dashboard.
+                                // It does NOT merge Actions which could be part of the Action Definition since
+                                // the Actions are themselves Action Definitions.
+                                // i.e Confirm -> Accept action -> Open URL
+                                // The Confirm Action Definition contains the Accept action ->
+                                // The Accept action itself has an Action Definition with default values.
+                                // The last are not merged here but when the action is triggered.
                                 var mergedVars = MergeHelper(actionDefinitions[name].Vars, messageConfig);
                                 var mergedVarsDict = mergedVars as Dictionary<object, object>;
                                 var newVars = mergedVarsDict.ToDictionary(item => item.Key.ToString(), item => item.Value);

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Utilities/Constants.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Utilities/Constants.cs
@@ -175,6 +175,7 @@ namespace LeanplumSDK
             public const string CLOSE_URL = "Close URL";
             public const string HAS_DISMISS_BUTTON = "Has dismiss button";
             public const string OPEN_URL = "Open URL";
+            public const string OPEN_ACTION = "Open action";
             public const string TRACK_URL = "Track URL";
             public const string ACTION_URL = "Action URL";
             public const string TRACK_ACTION_URL = "Track Action URL";


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-293](https://leanplum.atlassian.net/browse/SDK-293)

## Background
Implement Inbox Open Action handling in Unity Native.

## Implementation
Build ActionContext for the Open Action of the Inbox Message. Run the Open Action as tracked action to execute the Open Action and track an Open event.

## Testing steps
Manual testing with Open Actions:
- Open URL with default URL and set URL
- Chain to a new message
- Chain to a new message with Open Action itself
- Campaign Composer chained Open Action

## Is this change backwards-compatible?
Yes