### PR TITLE
Move Request NoPendingDownloads

### DIFF
--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
@@ -494,11 +494,13 @@ namespace LeanplumSDK
                 {
                     OnVariablesChangedAndNoDownloadsPending();
                 }
-            };
-
-            LeanplumRequest.NoPendingDownloads += delegate
-            {
-                OnVariablesChangedAndNoDownloadsPending();
+                else
+                {
+                    LeanplumRequest.NoPendingDownloads += delegate
+                    {
+                        OnVariablesChangedAndNoDownloadsPending();
+                    };
+                }
             };
 
             string deviceId;


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-351](https://leanplum.atlassian.net/browse/SDK-351)

## Background
The `onVariablesChangedAndNoDownloadsPending` callback is executed twice on Start. The callback is executed from `VarCache.Update` and immediately from `LeanplumRequest.NoPendingDownloads` if there are no pending downloads.
The latter is executed on iOS and Android only if a `downloadFile` request is started. This differs from Unity Native where the handler is executed immediately when added to the `LeanplumRequest` if there are no Pending Downloads.

## Implementation
Move the `LeanplumRequest.NoPendingDownloads` so it is executed only when there are pending downloads. Otherwise, the callback is executed from `VarCache.Update`, resulting in only 1 execution at Start.

## Testing steps
Tested using an Asset File Variable to trigger download request at Start.

## Is this change backwards-compatible?
