### PR TITLE
Expose Vars Diffs

### DIFF
--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
@@ -43,6 +43,7 @@ import com.leanplum.callbacks.StartCallback;
 import com.leanplum.callbacks.VariableCallback;
 import com.leanplum.callbacks.VariablesChangedCallback;
 import com.leanplum.internal.Util;
+import com.leanplum.internal.VarCache;
 import com.leanplum.json.JsonConverter;
 import com.unity3d.player.UnityPlayer;
 
@@ -234,6 +235,10 @@ public class UnityBridge {
 
   public static String variants() {
     return gson.toJson(Leanplum.variants());
+  }
+
+  public static String vars() {
+    return gson.toJson(VarCache.getDiffs());
   }
 
   public static String messageMetadata() {

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
@@ -442,6 +442,12 @@ namespace LeanplumSDK
             return (List<object>)Json.Deserialize(jsonString);
         }
 
+        public override IDictionary<string, object> Vars()
+        {
+            string jsonString = NativeSDK.CallStatic<string>("vars");
+            return (Dictionary<string, object>)Json.Deserialize(jsonString);
+        }
+
         /// <summary>
         ///     Returns metadata for all active in-app messages.
         ///     Recommended only for debugging purposes and advanced use cases.

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
@@ -108,6 +108,9 @@ namespace LeanplumSDK
         [DllImport ("__Internal")]
         internal static extern string _variants();
 
+        [DllImport("__Internal")]
+        internal static extern string _vars();
+
         [DllImport ("__Internal")]
         internal static extern string _messageMetadata();
 
@@ -551,6 +554,12 @@ namespace LeanplumSDK
         public override List<object> Variants()
         {
             return (List<object>)Json.Deserialize(_variants());
+        }
+
+        public override IDictionary<string, object> Vars()
+        {
+            string jsonString = _vars();
+            return (Dictionary<string, object>)Json.Deserialize(jsonString);
         }
 
         /// <summary>

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Leanplum.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Leanplum.cs
@@ -730,6 +730,11 @@ namespace LeanplumSDK
             return LeanplumFactory.SDK.Variants();
         }
 
+        public static IDictionary<string, object> Vars()
+        {
+            return LeanplumFactory.SDK.Vars();
+        }
+
         /// <summary>
         ///     Returns metadata for all active in-app messages.
         ///     Recommended only for debugging purposes and advanced use cases.

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSDKObject.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSDKObject.cs
@@ -351,6 +351,8 @@ namespace LeanplumSDK
         /// </summary>
         public abstract List<object> Variants ();
 
+        public abstract IDictionary<string, object> Vars ();
+
         /// <summary>
         ///     Returns metadata for all active in-app messages.
         ///     Recommended only for debugging purposes and advanced use cases.

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
@@ -21,6 +21,7 @@ using LeanplumSDK.MiniJSON;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using UnityEngine;
 
@@ -967,6 +968,13 @@ namespace LeanplumSDK
         public override List<object> Variants()
         {
             return VarCache.Variants;
+        }
+
+        public override IDictionary<string, object> Vars()
+        {
+            // Return a copy
+            IDictionary<string, object> varsDict = Json.Deserialize(Json.Serialize(VarCache.Diffs)) as IDictionary<string, object>;
+            return varsDict;
         }
 
         /// <summary>

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
@@ -184,6 +184,11 @@ extern "C"
         return lp::to_json_string([Leanplum variants]);
     }
 
+    const char * _vars()
+    {
+        return lp::to_json_string([[LPVarCache sharedCache] diffs]);
+    }
+
     const char * _messageMetadata()
     {
         return lp::to_json_string([Leanplum messageMetadata]);


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-395](https://leanplum.atlassian.net/browse/SDK-395)

Expose the Variables Diffs

## Background

## Implementation
Example Usage:
```
Debug.Log($"Leanplum Vars: {Leanplum.Vars()}");
Debug.Log($"Leanplum Vars Count: {Leanplum.Vars().Count}");
var vals = Leanplum.Vars().Values.Select(c => c.ToString()).ToList();
Debug.Log($"Leanplum Vars Values: {string.Join(",", vals)}");
```

## Testing steps
Manual

## Is this change backwards-compatible?
Yes