### PR TITLE
[SDK-396] Parse correctly empty string

### DIFF
--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/MessageTemplates/EditorMessageTemplates.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/MessageTemplates/EditorMessageTemplates.cs
@@ -62,12 +62,12 @@ namespace LeanplumSDK
         {
             string configVars = $"{Constants.Args.GENERIC_DEFINITION_CONFIG}.vars";
             ActionArgs args = new ActionArgs()
-                .With<IDictionary<string, object>>(Constants.Args.GENERIC_DEFINITION_CONFIG, null)
-                .With<IDictionary<string, object>>(configVars, null);
+                .With<object>(Constants.Args.GENERIC_DEFINITION_CONFIG, null)
+                .With<Dictionary<string, object>>(configVars, null);
 
             ActionContext.ActionResponder responder = new ActionContext.ActionResponder((context) =>
             {
-                var messageConfig = context.GetObjectNamed<Dictionary<string, object>>(Constants.Args.GENERIC_DEFINITION_CONFIG);
+                var messageConfig = context.GetObjectNamed<object>(Constants.Args.GENERIC_DEFINITION_CONFIG);
                 var messageVars = context.GetObjectNamed<Dictionary<string, object>>(configVars);
                 StringBuilder builder = new StringBuilder();
                 NativeActionContext nativeContext = context as NativeActionContext;

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Utilities/MiniJSON.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Utilities/MiniJSON.cs
@@ -82,7 +82,8 @@ namespace LeanplumSDK.MiniJSON {
         /// <returns>An List&lt;object&gt;, a Dictionary&lt;string, object&gt;, a double, an integer,a string, null, true, or false</returns>
         public static object Deserialize(string json) {
             // save the string for debug information
-            if (json == null) {
+            if (string.IsNullOrEmpty(json))
+            {
                 return null;
             }
 


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-396](https://leanplum.atlassian.net/browse/SDK-396)

## Background
If Decryption fails, `String.Empty` is returned. This cannot be parsed by MiniJSON and throws an exception.
Such exception can be thrown in `VarCache.LoadDiffs` when calling `ApplyVariableDiffs`.
## Implementation
Return null for `String.Empty` when parsing JSON.
## Testing steps
```
var test = LeanplumSDK.MiniJSON.Json.Deserialize("");
```
The above line was previously throwing an exception:
```
OverflowException: Value was either too large or too small for a character.
at System.Convert.ToChar (System.Int32 value)
```
It now returns null.

Other cases remain unchanged:
```
var test = LeanplumSDK.MiniJSON.Json.Deserialize(" "); // returns null
var test = LeanplumSDK.MiniJSON.Json.Deserialize("  "); // returns null
```
## Is this change backwards-compatible?
Yes