### PR TITLE
[SDK-408] Unity Secured vars

### DIFF
--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
@@ -443,6 +443,21 @@ namespace LeanplumSDK
             return (List<object>)Json.Deserialize(jsonString);
         }
 
+        /// <summary>
+        /// Returns the last received signed variables.
+        /// If signature was not provided from server the
+        /// result of this method will be null.
+        /// </summary>
+        /// <returns> Returns <see cref="LeanplumSecuredVars"/> instance containing
+        /// variable's JSON and signature.
+        /// If signature was not downloaded from server, returns null.
+        /// </returns>
+        public override LeanplumSecuredVars SecuredVars()
+        {
+            // TODO: implement when Android SDK is ready
+            return null;
+        }
+
         public override IDictionary<string, object> Vars()
         {
             string jsonString = NativeSDK.CallStatic<string>("vars");

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
@@ -560,6 +560,21 @@ namespace LeanplumSDK
             return (List<object>)Json.Deserialize(_variants());
         }
 
+        /// <summary>
+        /// Returns the last received signed variables.
+        /// If signature was not provided from server the
+        /// result of this method will be null.
+        /// </summary>
+        /// <returns> Returns <see cref="LeanplumSecuredVars"/> instance containing
+        /// variable's JSON and signature.
+        /// If signature was not downloaded from server, returns null.
+        /// </returns>
+        public override LeanplumSecuredVars SecuredVars()
+        {
+            // TODO: implement when iOS SDK is ready
+            return null;
+        }
+
         public override IDictionary<string, object> Vars()
         {
             string jsonString = _vars();

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Leanplum.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Leanplum.cs
@@ -736,6 +736,20 @@ namespace LeanplumSDK
         }
 
         /// <summary>
+        /// Returns the last received signed variables.
+        /// If signature was not provided from server the
+        /// result of this method will be null.
+        /// </summary>
+        /// <returns> Returns <see cref="LeanplumSecuredVars"/> instance containing
+        /// variable's JSON and signature.
+        /// If signature was not downloaded from server, returns null.
+        /// </returns>
+        public static LeanplumSecuredVars SecuredVars()
+        {
+            return LeanplumFactory.SDK.SecuredVars();
+        }
+
+        /// <summary>
         ///     Returns metadata for all active in-app messages.
         ///     Recommended only for debugging purposes and advanced use cases.
         /// </summary>

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSDKObject.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSDKObject.cs
@@ -354,6 +354,17 @@ namespace LeanplumSDK
         public abstract IDictionary<string, object> Vars ();
 
         /// <summary>
+        /// Returns the last received signed variables.
+        /// If signature was not provided from server the
+        /// result of this method will be null.
+        /// </summary>
+        /// <returns> Returns <see cref="LeanplumSecuredVars"/> instance containing
+        /// variable's JSON and signature.
+        /// If signature was not downloaded from server, returns null.
+        /// </returns>
+        public abstract LeanplumSecuredVars SecuredVars ();
+
+        /// <summary>
         ///     Returns metadata for all active in-app messages.
         ///     Recommended only for debugging purposes and advanced use cases.
         /// </summary>

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSecuredVars.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSecuredVars.cs
@@ -1,19 +1,28 @@
 ﻿namespace LeanplumSDK
 {
+    /// <summary>
+    /// Represents Variables in JSON format, cryptographically signed from Leanplum server.
+    /// </summary>
     public class LeanplumSecuredVars
     {
-        private string json;
-        private string signature;
-        
-        public string varsJson
+        private readonly string json;
+        private readonly string signature;
+
+        /// <summary>
+        /// The JSON representation of the variables as received from Leanplum server.
+        /// </summary>
+        public string VarsJson
         {
             get
             {
                 return json;
             }
         }
-        
-        public string varsSignature
+
+        /// <summary>
+        /// Get the cryptographic signature of the variables.
+        /// </summary>
+        public string VarsSignature
         {
             get
             {

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSecuredVars.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSecuredVars.cs
@@ -1,0 +1,35 @@
+﻿namespace LeanplumSDK
+{
+    public class LeanplumSecuredVars
+    {
+        private string json;
+        private string signature;
+        
+        public string varsJson
+        {
+            get
+            {
+                return json;
+            }
+        }
+        
+        public string varsSignature
+        {
+            get
+            {
+                return signature;
+            }
+        }
+
+        internal LeanplumSecuredVars()
+        {
+
+        }
+
+        public LeanplumSecuredVars(string json, string signature) : base()
+        {
+            this.json = json;
+            this.signature = signature;
+        }
+    }
+}

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
@@ -584,6 +584,10 @@ namespace LeanplumSDK
                 bool isRegistered = (bool)Util.GetValueOrDefault(response, Constants.Keys.IS_REGISTERED, false);
                 bool syncInbox = (bool)Util.GetValueOrDefault(response, Constants.Keys.SYNC_INBOX, false);
 
+                string varsJson = Json.Serialize(values);
+                var signature = Util.GetValueOrDefault(response, Constants.Keys.VARS_SIGNATURE);
+                string varsSignature = signature != null ? signature.ToString() : null;
+
                 LeanplumRequest.Token = Util.GetValueOrDefault(response, Constants.Keys.TOKEN) as
                     string ?? "";
 
@@ -634,7 +638,7 @@ namespace LeanplumSDK
                     }
                 }
 
-                VarCache.ApplyVariableDiffs(values, messages, fileAttributes, variants);
+                VarCache.ApplyVariableDiffs(values, messages, fileAttributes, variants, varsJson, varsSignature);
                 _hasStarted = true;
                 startSuccessful = true;
                 OnStarted(true);
@@ -982,6 +986,11 @@ namespace LeanplumSDK
             return varsDict;
         }
 
+        public override LeanplumSecuredVars SecuredVars()
+        {
+            return VarCache.SecuredVars;
+        }
+
         /// <summary>
         ///     Return message metadata.
         ///     Used only for debugging purposes and advanced use cases.
@@ -1035,7 +1044,11 @@ namespace LeanplumSDK
                 var newVariants = Util.GetValueOrDefault(getVariablesResponse, Constants.Keys.VARIANTS) as List<object> ?? new List<object>();
                 bool syncInbox = (bool)Util.GetValueOrDefault(getVariablesResponse, Constants.Keys.SYNC_INBOX, false);
 
-                VarCache.ApplyVariableDiffs(newVarValues, newMessages, newVarFileAttributes, newVariants);
+                string varsJson = Json.Serialize(newVarValues);
+                var signature = Util.GetValueOrDefault(getVariablesResponse, Constants.Keys.VARS_SIGNATURE);
+                string varsSignature = signature != null ? signature.ToString() : null;
+
+                VarCache.ApplyVariableDiffs(newVarValues, newMessages, newVarFileAttributes, newVariants, varsJson, varsSignature);
 
                 // Download inbox messages
                 if (syncInbox)

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Utilities/Constants.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Utilities/Constants.cs
@@ -70,6 +70,8 @@ namespace LeanplumSDK
             internal const string TOKEN_KEY = "__leanplum_token";
             internal const string USERID_KEY = "___leanplum_userid";
             internal const string APP_INBOX_MESSAGES_KEY = "___leanplum_app_inbox_messages";
+            internal const string VARIABLES_SIGN_KEY = "__leanplum_variables_json";
+            internal const string VARIABLES_JSON_KEY = "__leanplum_variables_signature";
         }
 
         internal class Files
@@ -119,6 +121,7 @@ namespace LeanplumSDK
             internal const string DATA = "Data";
             internal const string ID = "id";
             internal const string ARGS = "args";
+            internal const string VARS_SIGNATURE = "varsSignature";
         }
 
         public class Kinds


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-408](https://leanplum.atlassian.net/browse/SDK-408)

## Background
Unity Native Secured Vars.
`LeanplumSecuredVars` will contain the JSON and signature of the variables.
Accessed via `Leanplum.SecuredVars()`.

## Implementation

## Testing steps

## Is this change backwards-compatible?
