### PR TITLE
[SDK-435] SecuredVars iOS and Android

### DIFF
--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
@@ -242,6 +242,10 @@ public class UnityBridge {
     return gson.toJson(Leanplum.variants());
   }
 
+  public static String securedVars() {
+    return gson.toJson(Leanplum.securedVars());
+  }
+
   public static String vars() {
     return gson.toJson(VarCache.getDiffs());
   }

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
@@ -454,7 +454,12 @@ namespace LeanplumSDK
         /// </returns>
         public override LeanplumSecuredVars SecuredVars()
         {
-            // TODO: implement when Android SDK is ready
+            string jsonString = NativeSDK.CallStatic<string>("securedVars");
+            if (!string.IsNullOrEmpty(jsonString))
+            {
+                var varsDict = (Dictionary<string, object>)Json.Deserialize(jsonString);
+                return LeanplumSecuredVars.FromDictionary(varsDict);
+            }
             return null;
         }
 

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
@@ -109,6 +109,9 @@ namespace LeanplumSDK
         internal static extern string _variants();
 
         [DllImport("__Internal")]
+        internal static extern string _securedVars();
+
+        [DllImport("__Internal")]
         internal static extern string _vars();
 
         [DllImport ("__Internal")]
@@ -577,7 +580,12 @@ namespace LeanplumSDK
         /// </returns>
         public override LeanplumSecuredVars SecuredVars()
         {
-            // TODO: implement when iOS SDK is ready
+            string jsonString = _securedVars();
+            if (!string.IsNullOrEmpty(jsonString))
+            {
+                var varsDict = (Dictionary<string, object>)Json.Deserialize(jsonString);
+                return LeanplumSecuredVars.FromDictionary(varsDict);
+            }
             return null;
         }
 

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSecuredVars.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSecuredVars.cs
@@ -1,4 +1,6 @@
-﻿namespace LeanplumSDK
+﻿using System.Collections.Generic;
+
+namespace LeanplumSDK
 {
     /// <summary>
     /// Represents Variables in JSON format, cryptographically signed from Leanplum server.
@@ -39,6 +41,21 @@
         {
             this.json = json;
             this.signature = signature;
+        }
+
+        public static LeanplumSecuredVars FromDictionary(Dictionary<string, object> varsDict)
+        {
+            if (varsDict != null)
+            {
+                string json = Util.GetValueOrDefault(varsDict, "json")?.ToString();
+                string signature = Util.GetValueOrDefault(varsDict, "signature")?.ToString();
+                if (!string.IsNullOrEmpty(json) && !string.IsNullOrEmpty(signature))
+                {
+                    LeanplumSecuredVars leanplumSecuredVars = new(json, signature);
+                    return leanplumSecuredVars;
+                }
+            }
+            return null;
         }
     }
 }

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSecuredVars.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSecuredVars.cs
@@ -47,8 +47,8 @@ namespace LeanplumSDK
         {
             if (varsDict != null)
             {
-                string json = Util.GetValueOrDefault(varsDict, "json")?.ToString();
-                string signature = Util.GetValueOrDefault(varsDict, "signature")?.ToString();
+                string json = Util.GetValueOrDefault(varsDict, Constants.Keys.SECURED_VARS_JSON_KEY)?.ToString();
+                string signature = Util.GetValueOrDefault(varsDict, Constants.Keys.SECURED_VARS_SIGNATURE_KEY)?.ToString();
                 if (!string.IsNullOrEmpty(json) && !string.IsNullOrEmpty(signature))
                 {
                     LeanplumSecuredVars leanplumSecuredVars = new(json, signature);

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Utilities/Constants.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Utilities/Constants.cs
@@ -122,6 +122,8 @@ namespace LeanplumSDK
             internal const string ID = "id";
             internal const string ARGS = "args";
             internal const string VARS_SIGNATURE = "varsSignature";
+            public const string SECURED_VARS_SIGNATURE_KEY = "signature";
+            public const string SECURED_VARS_JSON_KEY = "json";
         }
 
         public class Kinds

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
@@ -64,6 +64,20 @@ const char *__NativeCallbackMethod = "NativeCallback";
 @end
 // Variable Delegate class END
 
+@interface LPSecuredVars (JsonKeys)
+@end
+
+@implementation LPSecuredVars (JsonKeys)
++ (NSString *)securedVarsKey
+{
+    return @"json";
+}
++ (NSString *)securedVarsSignatureKey
+{
+    return @"signature";
+}
+@end
+
 extern "C"
 {
     /**
@@ -188,6 +202,19 @@ extern "C"
     const char * _variants()
     {
         return lp::to_json_string([Leanplum variants]);
+    }
+
+    const char * _securedVars()
+    {   
+        LPSecuredVars *securedVars = [Leanplum securedVars];
+        if (securedVars) {
+            NSDictionary *securedVarsDict = @{
+                [LPSecuredVars securedVarsKey]: [securedVars varsJson],
+                [LPSecuredVars securedVarsSignatureKey]: [securedVars varsSignature]
+            };
+            return lp::to_json_string(securedVarsDict);
+        }
+        return NULL;
     }
 
     const char * _vars()


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-435](https://leanplum.atlassian.net/browse/SDK-435)

## Background
_Requires SecuredVars implementation in iOS and Android SDKs._

## Implementation
Get the SecuredVars from mobile SDK, serialize and send to Unity. Deserialize into `LeanplumSecuredVars` object in Unity.

## Testing steps

## Is this change backwards-compatible?
