### PR TITLE
Prevent cast error

### DIFF
--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/MessageTemplates/EditorMessageTemplates.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/MessageTemplates/EditorMessageTemplates.cs
@@ -63,12 +63,13 @@ namespace LeanplumSDK
             string configVars = $"{Constants.Args.GENERIC_DEFINITION_CONFIG}.vars";
             ActionArgs args = new ActionArgs()
                 .With<object>(Constants.Args.GENERIC_DEFINITION_CONFIG, null)
-                .With<Dictionary<string, object>>(configVars, null);
+                .With<object>(configVars, null);
 
             ActionContext.ActionResponder responder = new ActionContext.ActionResponder((context) =>
             {
                 var messageConfig = context.GetObjectNamed<object>(Constants.Args.GENERIC_DEFINITION_CONFIG);
-                var messageVars = context.GetObjectNamed<Dictionary<string, object>>(configVars);
+                var messageVars = context.GetObjectNamed<object>(configVars);
+
                 StringBuilder builder = new StringBuilder();
                 NativeActionContext nativeContext = context as NativeActionContext;
                 if (nativeContext != null && !string.IsNullOrEmpty(nativeContext.Id))


### PR DESCRIPTION
## Background
The GenericActionDefinition logs cast error when Rich Interstitial is shown in Unity Editor due to the Fonts field which is not a primitive object.
Error logged (exception is caught):
`Error casting value for name: messageConfig.vars. Exception: Object must implement IConvertible.`
## Implementation
Fallback to object and do not convert and cast explicitly.
## Testing steps

## Is this change backwards-compatible?
Yes