### PR TITLE
[SDK-448] Action named responder

### DIFF
--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
@@ -50,6 +50,7 @@ import com.leanplum.internal.LeanplumInternal;
 import com.leanplum.internal.Util;
 import com.leanplum.internal.VarCache;
 import com.leanplum.json.JsonConverter;
+import com.leanplum.messagetemplates.MessageTemplates;
 import com.unity3d.player.UnityPlayer;
 
 public class UnityBridge {
@@ -60,7 +61,7 @@ public class UnityBridge {
 
   private static final String CLIENT = "unity-nativeandroid";
 
-  private static void makeCallbackToUnity(String message) {
+  static void makeCallbackToUnity(String message) {
     UnityPlayer.UnitySendMessage(unityGameObject, "NativeCallback", message);
   }
 
@@ -328,6 +329,11 @@ public class UnityBridge {
   }
 
   public static void onAction(final String name) {
+    // Initialize default templates to prevent defineAction:actionResponder to override
+    // the onAction that will be registered
+    if (!LeanplumInternal.hasCalledStart() && UnityPlayer.currentActivity != null){
+      MessageTemplates.register(UnityPlayer.currentActivity);
+    }
     Leanplum.onAction(name, new ActionCallback() {
       @Override
       public boolean onResponse(ActionContext context) {

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/ActionContext.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/ActionContext.cs
@@ -34,6 +34,14 @@ namespace LeanplumSDK
         public abstract void TrackMessageEvent(string eventName, double value, string info, IDictionary<string, object> param);
 
         /// <summary>
+        /// Sets a responder to be executed when an action is run.
+        /// </summary>
+        /// <param name="handler">the action responder to be invoked</param>
+        public abstract void SetActionNamedResponder(ActionResponder handler);
+
+        internal abstract void TriggerActionNamedResponder(ActionContext context);
+
+        /// <summary>
         /// Runs the action given by the "name" key.
         /// </summary>
         /// <param name="name">action name</param>

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/ActionContextAndroid.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/ActionContextAndroid.cs
@@ -10,6 +10,7 @@ namespace LeanplumSDK
     public class ActionContextAndroid : ActionContext
     {
         private AndroidJavaClass nativeHandle = null;
+        private ActionResponder runActionResponder;
         public override string Id { get; }
         public override string Name { get; }
 
@@ -30,6 +31,20 @@ namespace LeanplumSDK
         {
             var paramJson = param != null ? Json.Serialize(param) : "";
             nativeHandle.CallStatic("trackMessageEvent", Name, eventName, value, info, paramJson);
+        }
+
+        public override void SetActionNamedResponder(ActionResponder handler)
+        {
+            runActionResponder = handler;
+            nativeHandle.CallStatic("setActionNamedHandler", Name);
+        }
+
+        internal override void TriggerActionNamedResponder(ActionContext context)
+        {
+            if (runActionResponder != null)
+            {
+                runActionResponder.Invoke(context);
+            }
         }
 
         public override void RunActionNamed(string name)

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
@@ -65,6 +65,7 @@ namespace LeanplumSDK
         private Dictionary<int, Action> ForceContentUpdateCallbackDictionary = new Dictionary<int, Action>();
         private Dictionary<string, ActionContext.ActionResponder> ActionRespondersDictionary = new Dictionary<string, ActionContext.ActionResponder>();
         private Dictionary<string, List<ActionContext.ActionResponder>> OnActionRespondersDictionary = new Dictionary<string, List<ActionContext.ActionResponder>>();
+        private Dictionary<string, ActionContext> ActionContextsDictionary = new Dictionary<string, ActionContext>();
 
         static private int DictionaryKey = 0;
         private string gameObjectName;
@@ -508,8 +509,9 @@ namespace LeanplumSDK
             const string STARTED = "Started:";
             const string VARIABLE_VALUE_CHANGED = "VariableValueChanged:";
             const string FORCE_CONTENT_UPDATE_WITH_CALLBACK = "ForceContentUpdateWithCallback:";
-            const string ACTION_RESPONDER = "ActionResponder:";
-            const string ON_ACTION = "OnAction:";
+            const string DEFINE_ACTION_RESPONDER = "ActionResponder:";
+            const string ON_ACTION_RESPONDER = "OnAction:";
+            const string RUN_ACTION_NAMED_RESPONDER = "OnRunActionNamed:";
 
             if (message.StartsWith(VARIABLES_CHANGED))
             {
@@ -543,9 +545,9 @@ namespace LeanplumSDK
                     ForceContentUpdateCallbackDictionary.Remove(key);
                 }
             }
-            else if (message.StartsWith(ACTION_RESPONDER))
+            else if (message.StartsWith(DEFINE_ACTION_RESPONDER))
             {
-                string key = message.Substring(ACTION_RESPONDER.Length);
+                string key = message.Substring(DEFINE_ACTION_RESPONDER.Length);
                 // {actionName:messageId}
                 string actionName = key.Split(':')[0];
 
@@ -554,22 +556,49 @@ namespace LeanplumSDK
                 {
                     string messageId = key.Length > actionName.Length ? key.Substring(actionName.Length + 1) : string.Empty;
                     var context = new ActionContextAndroid(key, messageId);
+                    ActionContextsDictionary[key] = context;
                     callback(context);
                 }
             }
-            else if (message.StartsWith(ON_ACTION))
+            else if (message.StartsWith(ON_ACTION_RESPONDER))
             {
-                string key = message.Substring(ON_ACTION.Length);
+                string key = message.Substring(ON_ACTION_RESPONDER.Length);
                 string actionName = GetActionNameFromMessageKey(key);
 
                 if (OnActionRespondersDictionary.TryGetValue(actionName, out List<ActionContext.ActionResponder> callbacks))
                 {
-                    string messageId = GetMessageIdFromMessageKey(key, actionName);
-                    var context = new ActionContextAndroid(key, messageId);
+                    if (!ActionContextsDictionary.ContainsKey(key))
+                    {
+                        string messageId = GetMessageIdFromMessageKey(key);
+                        var newContext = new ActionContextAndroid(key, messageId);
+                        ActionContextsDictionary[key] = newContext;
+                    }
+
+                    ActionContext context = ActionContextsDictionary[key];
                     foreach (var callback in callbacks)
                     {
                         callback(context);
                     }
+                }
+            }
+            else if (message.StartsWith(RUN_ACTION_NAMED_RESPONDER))
+            {
+                char keysSeparator = '|';
+                string data = message.Substring(RUN_ACTION_NAMED_RESPONDER.Length);
+
+                string[] keys = data.Split(new char[] { keysSeparator }, StringSplitOptions.RemoveEmptyEntries);
+                if (keys.Length != 2)
+                {
+                    return;
+                }
+
+                string parentKey = keys[0];
+                string actionKey = keys[1];
+
+                if (ActionContextsDictionary.TryGetValue(parentKey, out ActionContext parentContext))
+                {
+                    var context = new ActionContextAndroid(actionKey, GetMessageIdFromMessageKey(actionKey));
+                    parentContext.TriggerActionNamedResponder(context);
                 }
             }
 
@@ -711,9 +740,9 @@ namespace LeanplumSDK
             if (!string.IsNullOrEmpty(actionId))
             {
                 string key = NativeSDK.CallStatic<string>("createActionContextForId", actionId);
-                string actionName = GetActionNameFromMessageKey(key);
-                string messageId = GetMessageIdFromMessageKey(key, actionName);
+                string messageId = GetMessageIdFromMessageKey(key);
                 var context = new ActionContextAndroid(key, messageId);
+                ActionContextsDictionary[key] = context;
                 return context;
             }
             return null;
@@ -730,8 +759,9 @@ namespace LeanplumSDK
             return key.Split(':')[0];
         }
 
-        private string GetMessageIdFromMessageKey(string key, string actionName)
+        private string GetMessageIdFromMessageKey(string key)
         {
+            string actionName = GetActionNameFromMessageKey(key);
             string messageId = key.Length > actionName.Length ? key.Substring(actionName.Length + 1) : string.Empty;
             return messageId;
         }

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/ActionContextApple.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/ActionContextApple.cs
@@ -55,6 +55,9 @@ namespace LeanplumSDK.Apple
         internal static extern void run_action_named(string id, string name);
 
         [DllImport("__Internal")]
+        internal static extern void set_action_named_responder(string id);
+
+        [DllImport("__Internal")]
         internal static extern void run_tracked_action_named(string id, string name);
 
         [DllImport("__Internal")]
@@ -68,6 +71,8 @@ namespace LeanplumSDK.Apple
         
         public override string Name { get; }
         public override string Id { get; }
+
+        private ActionResponder runActionResponder;
 
         internal ActionContextApple(string key, string messageId)
         {
@@ -85,6 +90,20 @@ namespace LeanplumSDK.Apple
         {
             var parameters = param != null ? Json.Serialize(param) : "";
             track_event(Name, eventName, value, parameters);
+        }
+
+        public override void SetActionNamedResponder(ActionResponder responder)
+        {
+            runActionResponder = responder;
+            set_action_named_responder(Name);
+        }
+
+        internal override void TriggerActionNamedResponder(ActionContext context)
+        {
+            if (runActionResponder != null)
+            {
+                runActionResponder.Invoke(context);
+            }
         }
 
         public override void RunActionNamed(string name)

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
@@ -700,7 +700,6 @@ namespace LeanplumSDK
                     {
                         callback(context);
                     }
-
                 }
             }
             else if (message.StartsWith(RUN_ACTION_NAMED_RESPONDER))

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
@@ -635,15 +635,6 @@ namespace LeanplumSDK
             const string ON_ACTION_RESPONDER = "OnAction:";
             const string RUN_ACTION_NAMED_RESPONDER = "OnRunActionNamed:";
 
-
-            string keysStr = string.Empty;
-            if (ActionContextsDictionary.Count > 0)
-            {
-                List<string> keyList = new List<string>(ActionContextsDictionary.Keys);
-                keysStr = string.Join(", ", keyList);
-            }
-            Debug.Log($"ActionContexts Keys: {keysStr}");
-
             if (message.StartsWith(VARIABLES_CHANGED))
             {
                 VariablesChanged?.Invoke();

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
@@ -174,6 +174,7 @@ namespace LeanplumSDK
         private Dictionary<int, Action> ForceContentUpdateCallbackDictionary = new Dictionary<int, Action>();
         private Dictionary<string, ActionContext.ActionResponder> ActionRespondersDictionary = new Dictionary<string, ActionContext.ActionResponder>();
         private Dictionary<string, List<ActionContext.ActionResponder>> OnActionRespondersDictionary = new Dictionary<string, List<ActionContext.ActionResponder>>();
+        private Dictionary<string, ActionContext> ActionContextsDictionary = new Dictionary<string, ActionContext>();
 
         static private int DictionaryKey = 0;
 
@@ -630,8 +631,18 @@ namespace LeanplumSDK
             const string STARTED = "Started:";
             const string VARIABLE_VALUE_CHANGED = "VariableValueChanged:";
             const string FORCE_CONTENT_UPDATE_WITH_CALLBACK = "ForceContentUpdateWithCallback:";
-            const string ACTION_RESPONDER = "ActionResponder:";
-            const string ON_ACTION = "OnAction:";
+            const string DEFINE_ACTION_RESPONDER = "ActionResponder:";
+            const string ON_ACTION_RESPONDER = "OnAction:";
+            const string RUN_ACTION_NAMED_RESPONDER = "OnRunActionNamed:";
+
+
+            string keysStr = string.Empty;
+            if (ActionContextsDictionary.Count > 0)
+            {
+                List<string> keyList = new List<string>(ActionContextsDictionary.Keys);
+                keysStr = string.Join(", ", keyList);
+            }
+            Debug.Log($"ActionContexts Keys: {keysStr}");
 
             if (message.StartsWith(VARIABLES_CHANGED))
             {
@@ -665,32 +676,60 @@ namespace LeanplumSDK
                     ForceContentUpdateCallbackDictionary.Remove(key);
                 }
             }
-            else if (message.StartsWith(ACTION_RESPONDER))
+            else if (message.StartsWith(DEFINE_ACTION_RESPONDER))
             {
-                string key = message.Substring(ACTION_RESPONDER.Length);
+                string key = message.Substring(DEFINE_ACTION_RESPONDER.Length);
                 string actionName = GetActionNameFromMessageKey(key);
 
                 ActionContext.ActionResponder callback;
                 if (ActionRespondersDictionary.TryGetValue(actionName, out callback))
                 {
-                    string messageId = GetMessageIdFromMessageKey(key, actionName);
+                    string messageId = GetMessageIdFromMessageKey(key);
                     var context = new ActionContextApple(key, messageId);
+                    ActionContextsDictionary[key] = context;
                     callback(context);
                 }
             }
-            else if (message.StartsWith(ON_ACTION))
+            else if (message.StartsWith(ON_ACTION_RESPONDER))
             {
-                string key = message.Substring(ON_ACTION.Length);
+                string key = message.Substring(ON_ACTION_RESPONDER.Length);
                 string actionName = GetActionNameFromMessageKey(key);
 
                 if (OnActionRespondersDictionary.TryGetValue(actionName, out List<ActionContext.ActionResponder> callbacks))
                 {
-                    string messageId = GetMessageIdFromMessageKey(key, actionName);
-                    var context = new ActionContextApple(key, messageId);
+                    if (!ActionContextsDictionary.ContainsKey(key))
+                    {
+                        string messageId = GetMessageIdFromMessageKey(key);
+                        var newContext = new ActionContextApple(key, messageId);
+                        ActionContextsDictionary[key] = newContext;
+                    }
+
+                    ActionContext context = ActionContextsDictionary[key];
                     foreach (var callback in callbacks)
                     {
                         callback(context);
                     }
+
+                }
+            }
+            else if (message.StartsWith(RUN_ACTION_NAMED_RESPONDER))
+            {
+                char keysSeparator = '|';
+                string data = message.Substring(RUN_ACTION_NAMED_RESPONDER.Length);
+
+                string[] keys = data.Split(new char[] { keysSeparator }, StringSplitOptions.RemoveEmptyEntries);
+                if (keys.Length != 2)
+                {
+                    return;
+                }
+
+                string parentKey = keys[0];
+                string actionKey = keys[1];
+
+                if (ActionContextsDictionary.TryGetValue(parentKey, out ActionContext parentContext))
+                {
+                    var context = new ActionContextApple(actionKey, GetMessageIdFromMessageKey(actionKey));
+                    parentContext.TriggerActionNamedResponder(context);
                 }
             }
 
@@ -706,8 +745,9 @@ namespace LeanplumSDK
             return key.Split(':')[0];
         }
 
-        private string GetMessageIdFromMessageKey(string key, string actionName)
+        private string GetMessageIdFromMessageKey(string key)
         {
+            string actionName = GetActionNameFromMessageKey(key);
             string messageId = key.Length > actionName.Length ? key.Substring(actionName.Length + 1) : string.Empty;
             return messageId;
         }
@@ -905,9 +945,10 @@ namespace LeanplumSDK
             if (!string.IsNullOrEmpty(actionId))
             {
                 string key = _createActionContextForId(actionId);
-                string actionName = GetActionNameFromMessageKey(key);
-                string messageId = GetMessageIdFromMessageKey(key, actionName);
+                string messageId = GetMessageIdFromMessageKey(key);
                 var context = new ActionContextApple(key, messageId);
+                ActionContextsDictionary[key] = context;
+
                 return context;
             }
             return null;

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
@@ -692,7 +692,7 @@ namespace LeanplumSDK
 
         public override void OnAction(string actionName, ActionContext.ActionResponder handler)
         {
-            // Not Implemented
+            LeanplumActionManager.RegisterOnActionResponder(actionName, handler);
         }
 
         /// <summary>

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/MessageTemplates/EditorMessageTemplates.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/MessageTemplates/EditorMessageTemplates.cs
@@ -95,10 +95,13 @@ namespace LeanplumSDK
             {
                 builder.AppendLine($"{IndentString(level)}{key}:");
                 var varDict = var as IDictionary<string, object>;
-                foreach (string keyDict in varDict.Keys)
+                if (varDict != null)
                 {
-                    BuildString(keyDict, varDict[keyDict], builder, ++level);
-                    level--;
+                    foreach (string keyDict in varDict.Keys)
+                    {
+                        BuildString(keyDict, varDict[keyDict], builder, ++level);
+                        level--;
+                    }
                 }
             }
             else if (var is IList)

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/NativeActionContext.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/NativeActionContext.cs
@@ -126,6 +126,16 @@ namespace LeanplumSDK
             throw new NotImplementedException();
         }
 
+        internal override void TriggerActionNamedResponder(ActionContext context)
+        {
+            //throw new NotImplementedException();
+        }
+
+        public override void SetActionNamedResponder(ActionResponder handler)
+        {
+            //throw new NotImplementedException();
+        }
+
         public override void RunActionNamed(string name)
         {
             object actionObject = Traverse(name);

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/NativeActionContext.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/NativeActionContext.cs
@@ -10,6 +10,7 @@ namespace LeanplumSDK
         private readonly string name;
         private readonly string id;
         private readonly IDictionary<string, object> vars;
+        private ActionResponder runActionResponder;
 
         public NativeActionContext(string id, string name, IDictionary<string, object> vars)
         {
@@ -128,12 +129,15 @@ namespace LeanplumSDK
 
         internal override void TriggerActionNamedResponder(ActionContext context)
         {
-            // Not Implemented
+            if (runActionResponder != null)
+            {
+                runActionResponder.Invoke(context);
+            }
         }
 
         public override void SetActionNamedResponder(ActionResponder handler)
         {
-            // Not Implemented
+            runActionResponder = handler;
         }
 
         public override void RunActionNamed(string name)
@@ -153,6 +157,9 @@ namespace LeanplumSDK
                     actionData = actionObject as Dictionary<string, object>;
                 }
             }
+
+            NativeActionContext runActionContext = new NativeActionContext(Id, name, actionData);
+            TriggerActionNamedResponder(runActionContext);
 
             if (actionData != null)
             {

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/NativeActionContext.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/NativeActionContext.cs
@@ -128,12 +128,12 @@ namespace LeanplumSDK
 
         internal override void TriggerActionNamedResponder(ActionContext context)
         {
-            //throw new NotImplementedException();
+            // Not Implemented
         }
 
         public override void SetActionNamedResponder(ActionResponder handler)
         {
-            //throw new NotImplementedException();
+            // Not Implemented
         }
 
         public override void RunActionNamed(string name)

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumActionContextBridge.h
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumActionContextBridge.h
@@ -25,5 +25,6 @@
 
 @interface LeanplumActionContextBridge : NSObject
 + (NSMutableDictionary<NSString *, LPActionContext *> *) sharedActionContexts;
++ (NSString *) addActionContext:(LPActionContext *) context;
 @end
 #endif

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumActionContextBridge.mm
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumActionContextBridge.mm
@@ -24,12 +24,6 @@
 #import "LeanplumUnityHelper.h"
 #import "LeanplumIOSBridge.h"
 
-@interface LPActionContext()
-
-@property(strong, nonatomic) LeanplumActionBlock actionNamedResponder;
-
-@end
-
 static NSMutableDictionary<NSString *, LPActionContext *> *actionContexts;
 
 @implementation LeanplumActionContextBridge

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.h
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.h
@@ -1,0 +1,30 @@
+//
+//  Copyright (c) 2021 Leanplum. All rights reserved.
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+#ifndef LeanplumIOSBridge_h
+#define LeanplumIOSBridge_h
+
+#pragma once
+
+@interface LeanplumIOSBridge : NSObject
++ (void) sendMessageToUnity:(NSString *) messageName withKey: (NSString *)key;
+@end
+
+#endif /* LeanplumIOSBridge_h */

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
@@ -20,10 +20,13 @@
 
 #import <Foundation/Foundation.h>
 #import <Leanplum/Leanplum.h>
+#import <Leanplum/LPActionContext.h>
 #import <Leanplum/LPInternalState.h>
 #import <Leanplum/LPPushNotificationsManager.h>
 #import "LeanplumUnityHelper.h"
 #import "LeanplumActionContextBridge.h"
+
+#import "LeanplumIOSBridge.h"
 
 #define LEANPLUM_CLIENT @"unity-nativeios"
 
@@ -63,6 +66,16 @@ const char *__NativeCallbackMethod = "NativeCallback";
 
 @end
 // Variable Delegate class END
+
+@implementation LeanplumIOSBridge
+
++ (void) sendMessageToUnity:(NSString *) messageName withKey: (NSString *)key
+{
+    UnitySendMessage(__LPgameObject, __NativeCallbackMethod,
+                     [[NSString stringWithFormat:@"%@:%@", messageName, key] UTF8String]);
+}
+
+@end
 
 extern "C"
 {


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-448](https://leanplum.atlassian.net/browse/SDK-448)

## Background
Enables setting an `ActionContext.ActionResponder` responder to be invoked when an action is run - for example, a button click or message dismiss click (by a dismiss button click or outside tap). The responder is set to an ActionContext instance. This needs to be implemented inside an `OnAction` responder. It works for custom message templates as well.
Example code:
```csharp
ActionContext.ActionResponder runActionResponder = new ActionContext.ActionResponder((context) =>
{
    Debug.Log($"ActionResponder: runActionResponder name: {context.Name}"); // Example: Accept action, Dismiss action, Select button 1 action
    Debug.Log($"ActionResponder: runActionResponder id: {context.Id}"); // Message Id from which the action was run
// After an action is run, all default messages are dimissed
});

ActionContext.ActionResponder responder = new ActionContext.ActionResponder((context) =>
{
    Debug.Log($"ActionResponder: {context.Name}");
    Debug.Log($"ActionResponder: {context.Id}");

    context.SetActionNamedResponder(runActionResponder);
});

Leanplum.OnAction("HTML", responder);
Leanplum.OnAction("Confirm", responder);
Leanplum.OnAction("Alert", responder);
Leanplum.OnAction("Center Popup", responder);
Leanplum.OnAction("Interstitial", responder);
Leanplum.OnAction("Web Interstitial", responder);
Leanplum.OnAction("Push Ask to Ask", responder);
```

Bridge setting action named responder. Add Unity Native implementation.
Details in those PRs in iOS and Android:
[iOS PR](https://github.com/Leanplum/Leanplum-iOS-SDK/pull/441)
[Android PR](https://github.com/Leanplum/Leanplum-Android-SDK/pull/460)

## Implementation
The ActionContext is persisted in the bridge and in the LeanplumSDK in Unity (`LeanplumApple` and `LeanplumAndroid`). This ensures the same ActionContext instance is used across the responders (defineAction and onAction) and makes the ActionNamedResponder persisted correctly. This mimics iOS and Android behavior.

## Notes
If you are defining custom message templates (`DefineAction`), `OnAction` should be called after defining them.

If a context is created manually using `CreateContextForId`, it should be created right before it is going to be triggered, or ensure the same message will not be displayed in the meantime.

_Unity Native_
The ActionResponders should be non-blocking.
At the moment, OnAction for Editor Message Templates is not supported since they use the EditorDialog which is blocking the execution.

## Testing steps
Manual Unity, iOS and Android using custom builds based on the above PRs.

## Is this change backwards-compatible?
Yes