### PR TITLE
[SDK-484] Enable setting Log level. Enable MiPush.

### DIFF
--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
@@ -206,6 +206,18 @@ public class UnityBridge {
     Leanplum.start(bridgeContext, userId, attributes);
   }
 
+  public static void setLogLevel(int logLevel) {
+    Leanplum.setLogLevel(logLevel);
+  }
+
+  public static void setMiPushApplication(String miAppId, String miAppKey) {
+    try {
+      Class.forName("com.leanplum.LeanplumMiPushHandler").getDeclaredMethod("setApplication", String.class, String.class).invoke((Object)null, miAppId, miAppKey);
+    } catch (Throwable var3) {
+      com.leanplum.internal.Log.e("Failed to set up MiPush", var3);
+    }
+  }
+
   public static void trackPurchase(String eventName, double value, String currencyCode,
       String jsonParameters) {
     Leanplum.trackPurchase(eventName, value, currencyCode,

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
@@ -334,6 +334,16 @@ namespace LeanplumSDK
             NativeSDK.CallStatic("start", userId, Json.Serialize(attributes));
         }
 
+        public override void SetMiPushApplication(string miAppId, string miAppKey)
+        {
+            NativeSDK.CallStatic("setMiPushApplication", miAppId, miAppKey);
+        }
+
+        public override void SetLogLevel(Constants.LogLevel logLevel)
+        {
+            NativeSDK.CallStatic("setLogLevel", (int)logLevel);
+        }
+
         public override void ForceSyncVariables(Leanplum.SyncVariablesCompleted completedHandler)
         {
             // The Android SDK does not support this.

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
@@ -75,6 +75,9 @@ namespace LeanplumSDK
         [DllImport("__Internal")]
         internal static extern void _setEventsUploadInterval(int uploadInterval);
 
+        [DllImport("__Internal")]
+        internal static extern void _setLogLevel(int logLevel);
+
         [DllImport ("__Internal")]
         internal static extern void _setAppVersion(string version);
 
@@ -306,6 +309,11 @@ namespace LeanplumSDK
         public override void SetAppVersion(string version)
         {
             _setAppVersion(version);
+        }
+
+        public override void SetLogLevel(Constants.LogLevel logLevel)
+        {
+            _setLogLevel((int)logLevel);
         }
 
         /// <summary>

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Leanplum.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Leanplum.cs
@@ -230,6 +230,25 @@ namespace LeanplumSDK
         }
 
         /// <summary>
+        /// Enables Xiaomi MiPush integration. Available on Android only.
+        /// </summary>
+        /// <param name="miAppId"> The MiPush app id. </param>
+        /// <param name="miAppKey"> The MiPush app key. </param>
+        public static void SetMiPushApplication(string miAppId, string miAppKey)
+        {
+            LeanplumFactory.SDK.SetMiPushApplication(miAppId, miAppKey);
+        }
+
+        /// <summary>
+        /// Sets the logging level.
+        /// </summary>
+        /// <param name="logLevel"> Level to set. </param>
+        public static void SetLogLevel(Constants.LogLevel logLevel)
+        {
+            LeanplumFactory.SDK.SetLogLevel(logLevel);
+        }
+
+        /// <summary>
         ///     Traverses the variable structure with the specified path.
         ///     Path components can be either strings representing keys in a dictionary,
         ///     or integers representing indices in a list.

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSDKObject.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSDKObject.cs
@@ -151,6 +151,14 @@ namespace LeanplumSDK
 
         public virtual void RegisterForIOSRemoteNotifications() {}
 
+        public virtual void SetMiPushApplication(string miAppId, string miAppKey) { }
+
+        /// <summary>
+        /// Sets the logging level.
+        /// </summary>
+        /// <param name="logLevel"> Level to set. </param>
+        public virtual void SetLogLevel(Constants.LogLevel logLevel) { }
+
         /// <summary>
         ///     Traverses the variable structure with the specified path.
         ///     Path components can be either strings representing keys in a dictionary,

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Utilities/Constants.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Utilities/Constants.cs
@@ -231,7 +231,7 @@ namespace LeanplumSDK
             internal const string KINDS = "kinds";
             internal const string NEW_USER_ID = "newUserId";
             internal const string PARAMS = "params";
-            internal const string SDK_VERSION = "3.2.0";
+            internal const string SDK_VERSION = "sdkVersion";
             internal const string STATE = "state";
             internal const string TIME = "time";
             internal const string TOKEN = "token";
@@ -257,6 +257,26 @@ namespace LeanplumSDK
         {
             MESSAGE = 0x1,
             ACTION = 0x2
+        }
+
+        public enum LogLevel
+        {
+            /// <summary>
+            /// Disables logging.
+            /// </summary>
+            OFF,
+            /// <summary>
+            /// Logs only errors, enabled by default.
+            /// </summary>
+            ERROR,
+            /// <summary>
+            /// Logs informational messages including errors.
+            /// </summary>
+            INFO,
+            /// <summary>
+            /// Enables all levels including DEBUG logging of the SDK.
+            /// </summary>
+            DEBUG
         }
     }
 }

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
@@ -165,6 +165,11 @@ extern "C"
         return lp::to_string([Leanplum userId]);
     }
 
+    void _setLogLevel(int logLevel)
+    {
+        [Leanplum setLogLevel:(LPLogLevel)logLevel];
+    }
+
     void _setTestModeEnabled(bool isTestModeEnabled)
     {
         [Leanplum setTestModeEnabled:isTestModeEnabled];


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-484](https://leanplum.atlassian.net/browse/SDK-484)
JIRA Issue        | [SDK-483](https://leanplum.atlassian.net/browse/SDK-483)

## Background
Enables setting Log level on iOS and Android.
Enables MiPush setting of key and id.

The Android implementation is a cherry-pick from the MiPush support package (code changes + unity package).

## Implementation
Adds LogLevel enum to bridge iOS and Android log levels.

## Testing steps

## Is this change backwards-compatible?
Yes