### PR TITLE
Expose App inbox message data

### DIFF
--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
@@ -20,16 +20,12 @@
 package com.leanplum;
 
 import java.lang.reflect.Method;
-import java.text.Format;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.json.JSONArray;
-import org.json.JSONException;
 
 import android.content.Context;
 import android.util.Log;
@@ -43,11 +39,9 @@ import com.leanplum.callbacks.InboxSyncedCallback;
 import com.leanplum.callbacks.StartCallback;
 import com.leanplum.callbacks.VariableCallback;
 import com.leanplum.callbacks.VariablesChangedCallback;
-import com.leanplum.internal.ActionManager;
 import com.leanplum.internal.CollectionUtil;
 import com.leanplum.internal.Constants;
 import com.leanplum.internal.LeanplumInternal;
-import com.leanplum.internal.Util;
 import com.leanplum.internal.VarCache;
 import com.leanplum.json.JsonConverter;
 import com.leanplum.messagetemplates.MessageTemplates;
@@ -539,6 +533,11 @@ public class UnityBridge {
         message.put("expirationTimestamp", formatter.format(msg.getExpirationTimestamp()));
       }
       message.put("isRead", msg.isRead());
+      // Use the map directly instead of msg.getData()
+      // gson.toJson of JSONObject produces "nameValuePairs"
+      Map<String, ?> mapData =
+              CollectionUtil.uncheckedCast(msg.getContext().objectNamed(Constants.Keys.DATA));
+      message.put("data", mapData);
       messages.add(message);
     }
     return gson.toJson(messages);

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumInbox.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumInbox.cs
@@ -79,6 +79,11 @@ namespace LeanplumSDK
             public bool IsRead = false;
 
             /// <summary>
+            /// Dictionary containing message Advanced Data
+            /// </summary>
+            public IDictionary<string, object> Data = null;
+
+            /// <summary>
             /// ActionContext containing message data
             /// </summary>
             internal IDictionary<string, object> ActionContext = null;
@@ -227,57 +232,61 @@ namespace LeanplumSDK
             foreach (var msg in msgs)
             {
                 var dict = msg as Dictionary<string, object>;
-                var leanpluMessage = new Message();
+                var leanplumMessage = new Message();
 
                 if (dict.TryGetValue("id", out var id))
                 {
-                    leanpluMessage.Id = id as string;
+                    leanplumMessage.Id = id as string;
                 }
                 if (dict.TryGetValue("title", out var title))
                 {
-                    leanpluMessage.Title = title as string;
+                    leanplumMessage.Title = title as string;
                 }
                 if (dict.TryGetValue("subtitle", out var subtitle))
                 {
-                    leanpluMessage.Subtitle = subtitle as string;
+                    leanplumMessage.Subtitle = subtitle as string;
                 }
                 if (dict.TryGetValue("imageFilePath", out var imageFilePath))
                 {
                     if (imageFilePath is string value)
                     {
-                        leanpluMessage.ImageFilePath = value;
+                        leanplumMessage.ImageFilePath = value;
                     }
                 }
                 if (dict.TryGetValue("imageURL", out var imageURL))
                 {
                     if (imageURL is string value)
                     {
-                        leanpluMessage.ImageURL = value;
+                        leanplumMessage.ImageURL = value;
                     }
                 }
                 if (dict.TryGetValue("deliveryTimestamp", out var deliveryTimestamp))
                 {
                     if (deliveryTimestamp is string value)
                     {
-                        leanpluMessage.DeliveryTimestamp = DateTime.Parse(value);
+                        leanplumMessage.DeliveryTimestamp = DateTime.Parse(value);
                     }
                 }
                 if (dict.TryGetValue("expirationTimestamp", out var expirationTimestamp))
                 {
                     if (expirationTimestamp is string value)
                     {
-                        leanpluMessage.ExpirationTimestamp = DateTime.Parse(value);
+                        leanplumMessage.ExpirationTimestamp = DateTime.Parse(value);
                     }
                 }
                 if (dict.TryGetValue("isRead", out var isRead))
                 {
                     if (isRead is bool value)
                     {
-                        leanpluMessage.IsRead = value;
+                        leanplumMessage.IsRead = value;
                     }
                 }
+                if (dict.TryGetValue("data", out var data))
+                {
+                    leanplumMessage.Data = data as IDictionary<string, object>;
+                }
 
-                messages.Add(leanpluMessage);
+                messages.Add(leanplumMessage);
             }
             return messages;
         }

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumInboxNative.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumInboxNative.cs
@@ -248,6 +248,11 @@ namespace LeanplumSDK
                                                 {
                                                     message.ImageURL = image as string;
                                                 }
+
+                                                if (varsDict.TryGetValue(Constants.Keys.DATA, out var advancedData))
+                                                {
+                                                    message.Data = advancedData as IDictionary<string, object>;
+                                                }
                                             }
                                         }
                                     }
@@ -385,6 +390,11 @@ namespace LeanplumSDK
                     if (msgData.TryGetValue(Constants.Keys.MESSAGE_DATA, out var actionContext))
                     {
                         message.ActionContext = actionContext as IDictionary<string, object>;
+                        if (message.ActionContext != null &&
+                            message.ActionContext.TryGetValue(Constants.Keys.DATA, out var advancedData))
+                        {
+                            message.Data = advancedData as IDictionary<string, object>;
+                        }
                     }
 
                     inboxMessage.Add(message);

--- a/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
+++ b/Leanplum-Unity-SDK/Assets/Plugins/iOS/LeanplumIOSBridge.mm
@@ -691,6 +691,7 @@ extern "C"
                 @"deliveryTimestamp": deliveryTimestamp ?: [NSNull null],
                 @"expirationTimestamp": expirationTimestamp ?: [NSNull null],
                 @"isRead": @(message.isRead),
+                @"data": message.data ?: [NSNull null]
             };
             [messageData addObject:data];
         }


### PR DESCRIPTION
## Background
Access the app inbox message data from Advanced data in Unity, iOS, and Android.

## Implementation
Get the data from the message vars field on Unity Native. Load from Preferences since it is already saved as part of the ActionContext (messageData).

Include the data field in the serialized JSON from Android and iOS.
## Testing steps

## Is this change backwards-compatible?
Yes