### PR TITLE
Expose track google play purchase

### DIFF
--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
@@ -218,6 +218,14 @@ public class UnityBridge {
         JsonConverter.fromJson(jsonParameters));
   }
 
+  public static void trackGooglePlayPurchase(String item, long priceMicros,
+                                             String currencyCode, String purchaseData, String dataSignature,
+                                             String jsonParameters) {
+    Map<String, Object> params = JsonConverter.fromJson(jsonParameters);
+    Leanplum.trackGooglePlayPurchase(item, priceMicros, currencyCode,
+            purchaseData, dataSignature, params);
+  }
+
   public static void track(String eventName, double value, String info,
       String jsonParameters) {
     Leanplum.track(eventName, value, info,

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Android/LeanplumAndroid.cs
@@ -385,6 +385,25 @@ namespace LeanplumSDK
         }
 
         /// <summary>
+        ///     Logs in-app purchase data from Google Play.
+        /// </summary>
+        /// <param name="item">The name of the item purchased.</param>
+        /// <param name="priceMicros">The purchase price in micros.</param>
+        /// <param name="currencyCode">The ISO 4217 currency code.</param>
+        /// <param name="purchaseData">Purchase data from
+        /// com.android.vending.billing.util.Purchase.getOriginalJson().</param>
+        /// <param name="dataSignature">Purchase data signature from
+        /// com.android.vending.billing.util.Purchase.getSignature().</param>
+        /// <param name="parameters">Optional event parameters.</param>
+        public override void TrackGooglePlayPurchase(string item, long priceMicros,
+            string currencyCode, string purchaseData, string dataSignature,
+            IDictionary<string, object> parameters)
+        {
+            NativeSDK.CallStatic("trackGooglePlayPurchase", item, priceMicros, currencyCode,
+                purchaseData, dataSignature, Json.Serialize(parameters));
+        }
+
+        /// <summary>
         ///     Logs a particular event in your application. The string can be
         ///     any value of your choosing, and will show up in the dashboard.
         ///     To track purchases, use Leanplum.PURCHASE_EVENT_NAME as the event name.

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSDKObject.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSDKObject.cs
@@ -241,7 +241,6 @@ namespace LeanplumSDK
         ///     com.android.vending.billing.util.Purchase.getSignature().
         /// </param>
         /// <param name="parameters">Optional event parameters.</param>
-        [Obsolete("TrackGooglePlayPurchase is obsolete. Please use TrackPurchase.")]
         public virtual void TrackGooglePlayPurchase(string item, long priceMicros,
             string currencyCode, string purchaseData, string dataSignature,
             IDictionary<string, object> parameters)

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
@@ -737,7 +737,6 @@ namespace LeanplumSDK
             return false;
         }
 
-        [Obsolete("TrackGooglePlayPurchase is obsolete. Please use TrackPurchase.")]
         public override void TrackGooglePlayPurchase(string item, long priceMicros,
             string currencyCode, string purchaseData, string dataSignature,
             IDictionary<string, object> parameters)


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-590](https://leanplum.atlassian.net/browse/SDK-590)

## Background
Using TrackGooglePlayPurchase the purchase can be validated on the API.
## Implementation

## Testing steps
Manual
## Is this change backwards-compatible?
