### PR TITLE
Send message in parallel using OperationQueue

### DIFF
--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
@@ -43,6 +43,7 @@ import com.leanplum.callbacks.VariablesChangedCallback;
 import com.leanplum.internal.CollectionUtil;
 import com.leanplum.internal.Constants;
 import com.leanplum.internal.LeanplumInternal;
+import com.leanplum.internal.OperationQueue;
 import com.leanplum.internal.VarCache;
 import com.leanplum.json.JsonConverter;
 import com.leanplum.messagetemplates.MessageTemplates;
@@ -56,8 +57,14 @@ public class UnityBridge {
 
   private static final String CLIENT = "unity-nativeandroid";
 
-  static void makeCallbackToUnity(String message) {
-    UnityPlayer.UnitySendMessage(unityGameObject, "NativeCallback", message);
+  static void makeCallbackToUnity(final String message) {
+    final Runnable sendMessageOperation = new Runnable() {
+      @Override
+      public void run() {
+        UnityPlayer.UnitySendMessage(unityGameObject, "NativeCallback", message);
+      }
+    };
+    OperationQueue.sharedInstance().addParallelOperation(sendMessageOperation);
   }
 
   public static void initialize(String gameObject, String sdkVersion, String defaultDeviceId) {


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-704](https://leanplum.atlassian.net/browse/SDK-704)

## Background
Execute `UnitySendMessage` in parallel in the background using `OperationQueue`.
## Implementation

## Testing steps

## Is this change backwards-compatible?
