### PR TITLE
Expose 'addOnceVariablesChangedAndNoDownloadsPendingHandler' for Android and Native

### DIFF
--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/build.gradle
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/build.gradle
@@ -4,11 +4,11 @@ def LP_VERSION = "%LP_VERSION%"
 def LP_UNITY_VERSION = "%LP_UNITY_VERSION%"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 31
         versionCode 1
         versionName "${LP_UNITY_VERSION}"
 

--- a/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
+++ b/Leanplum-Android-SDK-Unity/android-unity-wrapper/src/main/java/com/leanplum/UnityBridge.java
@@ -588,4 +588,14 @@ public class UnityBridge {
   public static void inboxDisableImagePrefetching() {
     LeanplumInbox.disableImagePrefetching();
   }
+
+  public static void addOnceVariablesChangedAndNoDownloadsPendingHandler(final int key) {
+    Leanplum.addOnceVariablesChangedAndNoDownloadsPendingHandler(new VariablesChangedCallback() {
+      @Override
+      public void variablesChanged() {
+        String message = String.format("OnceVariablesChangedAndNoDownloadsPendingHandler:%d", key);
+        makeCallbackToUnity(message);
+      }
+    });
+  }
 }

--- a/Leanplum-Android-SDK-Unity/build.gradle
+++ b/Leanplum-Android-SDK-Unity/build.gradle
@@ -4,10 +4,10 @@ buildscript {
     
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.3.3'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -16,7 +16,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven {
             url "https://repo.leanplum.com/"

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Apple/LeanplumApple.cs
@@ -1018,6 +1018,12 @@ namespace LeanplumSDK
             return lp_triggerAction(actionId);
         }
 
+        public override void AddOnceVariablesChangedAndNoDownloadsPendingHandler(Leanplum.VariablesChangedAndNoDownloadsPendingHandler handler)
+        {
+            throw new NotImplementedException();
+            // TODO implement using iOS native method
+        }
+
         #endregion
     }
 }

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Leanplum.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Leanplum.cs
@@ -839,6 +839,12 @@ namespace LeanplumSDK
             LeanplumFactory.SDK.ForceContentUpdate(handler);
         }
 
+        public static void AddOnceVariablesChangedAndNoDownloadsPendingHandler(
+            VariablesChangedAndNoDownloadsPendingHandler handler)
+        {
+            LeanplumFactory.SDK.AddOnceVariablesChangedAndNoDownloadsPendingHandler(handler);
+        }
+
         public static void OnAction(string actionName, ActionContext.ActionResponder handler)
         {
             LeanplumFactory.SDK.OnAction(actionName, handler);

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSDKObject.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/LeanplumSDKObject.cs
@@ -418,6 +418,17 @@ namespace LeanplumSDK
         /// </param>
         public abstract void ForceContentUpdate(Leanplum.ForceContentUpdateHandler handler);
 
+        /// <summary>
+        ///     Registers a handler to be called when variables are fetched and no downloads
+        ///     are pending. The handler will be called only once.
+        /// </summary>
+        /// <param name="handler">
+        ///     The handler to execute once variables are fetched and there
+        ///     aren't any pending downloads.
+        /// </param>
+        public abstract void AddOnceVariablesChangedAndNoDownloadsPendingHandler(
+            Leanplum.VariablesChangedAndNoDownloadsPendingHandler handler);
+
         public abstract void DefineAction(string name, Constants.ActionKind kind, ActionArgs args,
             IDictionary<string, object> options, ActionContext.ActionResponder responder);
 

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
@@ -1464,6 +1464,26 @@ namespace LeanplumSDK
             return variable;
         }
 
+        public override void AddOnceVariablesChangedAndNoDownloadsPendingHandler(
+            Leanplum.VariablesChangedAndNoDownloadsPendingHandler handler)
+        {
+            if (_hasStarted &&
+                    VarCache.HasReceivedDiffs &&
+                    FileTransferManager.PendingDownloads == 0)
+            {
+                handler();
+            }
+            else
+            {
+                void internalHandler()
+                {
+                    handler();
+                    variablesChangedAndNoDownloadsPending -= internalHandler;
+                };
+                variablesChangedAndNoDownloadsPending += internalHandler;
+            }
+        }
+
         #endregion
     }
 }

--- a/Leanplum-Unity-SDK/Assets/Plugins/Android/mainTemplate.gradle
+++ b/Leanplum-Unity-SDK/Assets/Plugins/Android/mainTemplate.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.5'
 
     // implementation(name: "com.leanplum.unity-wrapper-${LEANPLUM_SDK_VERSION}", ext:'aar')
+    //implementation project(':android-unity-wrapper')
 **DEPS**}
 
 android {

--- a/Leanplum-Unity-SDK/Assets/Plugins/Android/settingsTemplate.gradle
+++ b/Leanplum-Unity-SDK/Assets/Plugins/Android/settingsTemplate.gradle
@@ -1,0 +1,10 @@
+include ':launcher', ':unityLibrary'
+
+// Steps to configure the Leanplum native SDK wrapper dependency as a source code:
+// 1. In settings.gradle uncomment ':android-unity-wrapper' project.
+// 2. In build.gradle uncomment ':android-unity-wrapper' dependency.
+// 3. In build.gradle comment the line: implementation(name: "com.leanplum.unity-wrapper-XXX", ext:'aar').
+
+//include ':android-unity-wrapper'
+//project(':android-unity-wrapper').projectDir = new File("$rootDir/../Leanplum-Android-SDK-Unity/android-unity-wrapper")
+**INCLUDES**

--- a/Leanplum-Unity-SDK/Assets/Plugins/Android/settingsTemplate.gradle.meta
+++ b/Leanplum-Unity-SDK/Assets/Plugins/Android/settingsTemplate.gradle.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c2953c2781dff459bb6baa0aeff95b03
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
… source.

What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2377](https://wizrocket.atlassian.net/browse/SDK-2377)
People Involved   | @hborisoff 

## Implementation
1. Expose `Leanplum.addOnceVariablesChangedAndNoDownloadsPendingHandler` from Android and Native. There is an empty method for iOS.
2. Enable `android-unity-wrapper` module to be accessible by source code when compiling the exported Android project from Unity. To enable it follow the steps from `settings.gradle` file. The exported Android project must be in the root directory of the repository.