### PR TITLE
Fix isEditor when using simulator

### DIFF
--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Prefab/LeanplumWrapper.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Prefab/LeanplumWrapper.cs
@@ -35,14 +35,16 @@ public class LeanplumWrapper : MonoBehaviour
 		}
 		else
 		{
-			// NOTE: Currently, the native iOS and Android SDKs do not support Unity Asset Bundles.
-			// If you require the use of asset bundles, use LeanplumNative on all platforms.
-			#if UNITY_IPHONE
-			LeanplumFactory.SDK = new LeanplumApple();
-			#elif UNITY_ANDROID
-			LeanplumFactory.SDK = new LeanplumAndroid();
-			#else
-			LeanplumFactory.SDK = new LeanplumNative();
+            #if UNITY_EDITOR
+            LeanplumFactory.SDK = new LeanplumNative();
+            // NOTE: Currently, the native iOS and Android SDKs do not support Unity Asset Bundles.
+            // If you require the use of asset bundles, use LeanplumNative on all platforms.
+            #elif UNITY_IPHONE
+            LeanplumFactory.SDK = new LeanplumApple();
+            #elif UNITY_ANDROID
+            LeanplumFactory.SDK = new LeanplumAndroid();
+            #else
+            LeanplumFactory.SDK = new LeanplumNative();
             #endif
         }
     }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2476](https://wizrocket.atlassian.net/browse/SDK-2476)
People Involved   | @nzagorchev 

## Background
`Application.isEditor` check incorrectly returns false, resulting in the LeanplumApple or LeanplumAndroid SDK being used.
This reproduces when using the simulator on LTS 2020 (2020.3.30f1) with the [Device Simulator package](https://docs.unity3d.com/Packages/com.unity.device-simulator@3.0/manual/index.html).

The check correctly returns true if using LTS 2021 (2021.3.15f1) since the package is built in.

For more context check the JIRA and [this unity forum thread](https://forum.unity.com/threads/how-to-know-if-a-script-is-running-inside-unity-editor-when-using-device-simulator.921827/#post-6801644).

## Implementation
Use the `#if UNITY_EDITOR` is defined macro.

Other options evaluated were using `Application.installMode` or `UnityEngine.Device.Application.isEditor`.

## Testing steps

## Is this change backwards-compatible?
