### PR TITLE
iOS dynamic framework updates

### DIFF
--- a/Leanplum-Unity-SDK/Assets/Editor/LeanplumApplePostProcessor.cs
+++ b/Leanplum-Unity-SDK/Assets/Editor/LeanplumApplePostProcessor.cs
@@ -1,5 +1,4 @@
 ﻿#if UNITY_EDITOR
-using System;
 using System.IO;
 using UnityEditor;
 using UnityEditor.Callbacks;
@@ -11,13 +10,15 @@ namespace Leanplum.Private
 {
     class LeanplumApplePostProcessor
     {
-        const string FRAMEWORK_NAME = "Leanplum.framework";
-        const string XCFRAMEWORK_NAME = "Leanplum.xcframework";
+        private static readonly string[] FRAMEWORKS = new string[] { "Leanplum", "CleverTapSDK", "SDWebImage" };
         const string DEVICE_SLICE = "ios-arm64";
         const string SIMULATOR_SLICE = "ios-arm64_x86_64-simulator";
         const string DEVICE_SLICE_ARMV7 = "ios-arm64_armv7";
         const string SIMULATOR_SLICE_I386 = "ios-arm64_i386_x86_64-simulator";
         const string DEFAULT_LOCATION_IN_PROJECT = "Frameworks/Plugins/iOS";
+
+        const string ENABLE_BITCODE = "ENABLE_BITCODE";
+        const string NO = "NO";
 
         [PostProcessBuild]
         public static void OnPostprocessBuild(BuildTarget buildTarget, string path)
@@ -26,15 +27,20 @@ namespace Leanplum.Private
                 return;
 
             iOSSdkVersion target = PlayerSettings.iOS.sdkVersion;
-            SetupXcFramework(path, target == iOSSdkVersion.DeviceSDK);
+            foreach (string framework in FRAMEWORKS)
+            {
+                SetupXcFramework(framework, path, target == iOSSdkVersion.DeviceSDK);
+            }
+
             DisableBitcode(path);
-            AddCodeSignScriptBuildPhase(path);
         }
 
-        internal static void SetupXcFramework(string path, bool useDevice = true)
+        internal static void SetupXcFramework(string name, string path, bool useDevice = true)
         {
-            string xcFrameworkDevicePath = Path.Combine(XCFRAMEWORK_NAME, DEVICE_SLICE, FRAMEWORK_NAME);
-            string xcFrameworkSimulatorPath = Path.Combine(XCFRAMEWORK_NAME, SIMULATOR_SLICE, FRAMEWORK_NAME);
+            string xcframeworkName = $"{name}.xcframework";
+            string frameworkName = $"{name}.framework";
+            string xcFrameworkDevicePath = Path.Combine(xcframeworkName, DEVICE_SLICE, frameworkName);
+            string xcFrameworkSimulatorPath = Path.Combine(xcframeworkName, SIMULATOR_SLICE, frameworkName);
 
             PBXProject project = GetPBXProject(path, out string pbxProjectPath);
 
@@ -48,42 +54,42 @@ namespace Leanplum.Private
             {
                 if (string.IsNullOrEmpty(fileGuid))
                 {
-                    Debug.Log($"Device {FRAMEWORK_NAME} not found in Xcode project. Path: {frameworkPath}");
+                    Debug.Log($"Device {frameworkName} not found in Xcode project. Path: {frameworkPath}");
                     return;
                 }
 
-                string xcFrameworkSimulatorDirPath = Path.Combine(path, DEFAULT_LOCATION_IN_PROJECT, XCFRAMEWORK_NAME, SIMULATOR_SLICE);
+                string xcFrameworkSimulatorDirPath = Path.Combine(path, DEFAULT_LOCATION_IN_PROJECT, xcframeworkName, SIMULATOR_SLICE);
                 if (!Directory.Exists(xcFrameworkSimulatorDirPath))
-                    xcFrameworkSimulatorDirPath = Path.Combine(path, DEFAULT_LOCATION_IN_PROJECT, XCFRAMEWORK_NAME, SIMULATOR_SLICE_I386);
+                    xcFrameworkSimulatorDirPath = Path.Combine(path, DEFAULT_LOCATION_IN_PROJECT, xcframeworkName, SIMULATOR_SLICE_I386);
 
-                Setup(project, fileGuidSim, xcFrameworkSimulatorDirPath, fileGuid);
+                Setup(project, frameworkName, fileGuidSim, xcFrameworkSimulatorDirPath, fileGuid);
             }
             else
             {
                 if (string.IsNullOrEmpty(fileGuidSim))
                 {
-                    Debug.Log($"Simulator {FRAMEWORK_NAME} not found in Xcode project. Path: {frameworkPathSim}");
+                    Debug.Log($"Simulator {frameworkName} not found in Xcode project. Path: {frameworkPathSim}");
                     return;
                 }
 
-                string xcFrameworkDeviceDirPath = Path.Combine(path, DEFAULT_LOCATION_IN_PROJECT, XCFRAMEWORK_NAME, DEVICE_SLICE);
+                string xcFrameworkDeviceDirPath = Path.Combine(path, DEFAULT_LOCATION_IN_PROJECT, xcframeworkName, DEVICE_SLICE);
                 if (!Directory.Exists(xcFrameworkDeviceDirPath))
-                    xcFrameworkDeviceDirPath = Path.Combine(path, DEFAULT_LOCATION_IN_PROJECT, XCFRAMEWORK_NAME, DEVICE_SLICE_ARMV7);
+                    xcFrameworkDeviceDirPath = Path.Combine(path, DEFAULT_LOCATION_IN_PROJECT, xcframeworkName, DEVICE_SLICE_ARMV7);
 
-                Setup(project, fileGuid, xcFrameworkDeviceDirPath, fileGuidSim);
+                Setup(project, frameworkName, fileGuid, xcFrameworkDeviceDirPath, fileGuidSim);
             }
 
             project.WriteToFile(pbxProjectPath);
         }
 
-        private static void Setup(PBXProject project, string fileGuidToRemove, string pathToRemove, string fileGuid)
+        private static void Setup(PBXProject project, string frameworkName, string fileGuidToRemove, string pathToRemove, string fileGuid)
         {
             string targetGuid = project.GetUnityMainTargetGuid();
 
             // Remove simulator/device framework
             if (!string.IsNullOrEmpty(fileGuidToRemove))
             {
-                project.RemoveFrameworkFromProject(fileGuidToRemove, FRAMEWORK_NAME);
+                project.RemoveFrameworkFromProject(fileGuidToRemove, frameworkName);
                 project.RemoveFile(fileGuidToRemove);
             }
 
@@ -105,49 +111,22 @@ namespace Leanplum.Private
             return project;
         }
 
+        /// <summary>
+        /// Building with bitcode is deprecated in Xcode 14
+        /// </summary>
+        /// <param name="path"></param>
         private static void DisableBitcode(string path)
         {
+            PBXProject pbxProject = GetPBXProject(path, out string pbxProjectPath);
             // Unity Framework
-            PBXProject pbxProject = GetPBXProject(path, out string pbxProjectPath);
-            var target = pbxProject.GetUnityFrameworkTargetGuid();
-            pbxProject.SetBuildProperty(target, "ENABLE_BITCODE", "NO");
-            pbxProject.WriteToFile(pbxProjectPath);
-        }
-
-        private static string AddCodeSignScriptBuildPhase(string path)
-        {
-            PBXProject pbxProject = GetPBXProject(path, out string pbxProjectPath);
+            var frameworkTarget = pbxProject.GetUnityFrameworkTargetGuid();
+            pbxProject.SetBuildProperty(frameworkTarget, ENABLE_BITCODE, NO);
             // Unity iPhone
-            string targetGuid = pbxProject.GetUnityMainTargetGuid();
-            string scriptGuid = pbxProject.AddShellScriptBuildPhase(targetGuid, "Code Sign", "/bin/sh", script);
-            pbxProject.WriteToFile(pbxProjectPath);
-            return scriptGuid;
-        }
+            var mainTarget = pbxProject.GetUnityMainTargetGuid();
+            pbxProject.SetBuildProperty(mainTarget, ENABLE_BITCODE, NO);
 
-        static readonly string script = @"
-        # Populate a variable with the current code signing identity if it's available in the environment.
-        SIGNING_IDENTITY=""${EXPANDED_CODE_SIGN_IDENTITY:-$CODE_SIGN_IDENTITY}""
-        
-        # Populate a variable with the current code signing flags and options in the environment.
-        OTHER_CODE_SIGN_FLAGS=${OTHER_CODE_SIGN_FLAGS:-}
-        
-        TARGET_FRAMEWORKS_PATH=""${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/""
-        # Re-sign the packaged frameworks using the application's details.
-        if [ -n ""${SIGNING_IDENTITY}"" ]; then
-            if [[ -d $TARGET_FRAMEWORKS_PATH ]]
-            then
-                find ""$TARGET_FRAMEWORKS_PATH"" \
-                -name ""*.framework"" \
-                -type d \
-                -exec codesign ${OTHER_CODE_SIGN_FLAGS} \
-                    --force \
-                    --sign ""${SIGNING_IDENTITY}"" \
-                    --options runtime \
-                    --deep \
-                    {} \;
-        fi
-        fi
-        ";
+            pbxProject.WriteToFile(pbxProjectPath);
+        }
     }
 }
 #endif

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,3 @@ unitypackage:
 
 unitypackage-copy-beta:
 	./build.sh --apple-sdk-version=${IOS_SDK_VERSION} --android-sdk-version=${ANDROID_SDK_VERSION} --version=${UNITY_VERSION} --unity-editor-version=${UNITY_EDITOR_VERSION} --apple-copy
-
-unitypackage-without-simulator:
-	./build.sh --apple-sdk-version=${IOS_SDK_VERSION} --android-sdk-version=${ANDROID_SDK_VERSION} --version=${UNITY_VERSION} --unity-editor-version=${UNITY_EDITOR_VERSION} --no-simulator

--- a/build.sh
+++ b/build.sh
@@ -12,8 +12,6 @@ PATH_TO_UNITY_ROOT="/Applications/Unity/Unity.app"
 
 UNITY_EDITOR_VERSION=""
 
-REMOVE_SIMULATOR_ARCH=false
-
 XCFRAMEWORKS=("Leanplum" "CleverTapSDK" "SDWebImage")
 
 #######################################
@@ -84,11 +82,6 @@ extract_ios_sdk()
 
   rm -rf "/tmp/Leanplum-${version}.zip"
   rm -rf "/tmp/Leanplum-${version}"
-
-  if [ "$REMOVE_SIMULATOR_ARCH" = true ] ; then
-    echo "Removing x86_64 & i386 architecture from iOS library"
-    rm -rf "/tmp/Leanplum-${version}.xcframework/ios-arm64_x86_64-simulator"
-  fi
 }
 
 #######################################
@@ -271,10 +264,6 @@ main() {
       ;;
       --stacktrace)
       set -o xtrace
-      shift
-      ;;
-      --no-simulator)
-      REMOVE_SIMULATOR_ARCH=true
       shift
       ;;
     esac

--- a/build.sh
+++ b/build.sh
@@ -92,6 +92,34 @@ extract_ios_sdk()
 }
 
 #######################################
+# Copies Leanplum dynamic xcframework and its dependencies.
+# Globals:
+#   XCFRAMEWORKS
+# Arguments:
+#   The version to use, e.g. "1.2.3"
+# Returns:
+#   None
+#######################################
+prepare_ios()
+{
+  local version=$1
+  echo "Preparing iOS dependencies..."
+
+  # Remove all xcframeworks
+  find "Leanplum-Unity-SDK/Assets/Plugins/iOS" \
+  -name "*.xcframework" \
+  -type d \
+  -exec sh -c 'if [ -d {} ]; then rm -rf {};fi' \;
+
+  # Add all xcframeworks for specified version
+  for i in "${XCFRAMEWORKS[@]}"
+  do
+    cp -r "/tmp/Leanplum-$version-dynamic/$i.xcframework" \
+    "Leanplum-Unity-SDK/Assets/Plugins/iOS/"
+  done
+}
+
+#######################################
 # Copies the iOS SDK from project directory. Name should be in format Leanplum-${version}.zip
 # Globals:
 #   None
@@ -172,20 +200,7 @@ get_unity_from_hub() {
 #   None
 #######################################
 build() {
-  echo "Preparing dependencies..."
-
-  # Copy AppleSDK
-  find "Leanplum-Unity-SDK/Assets/Plugins/iOS" \
-  -name "*.xcframework" \
-  -type d \
-  -exec rm -rf {} \;
-
-  for i in "${XCFRAMEWORKS[@]}"
-  do
-    cp -r "/tmp/Leanplum-6.0.2-dynamic/$i.xcframework" \
-    "Leanplum-Unity-SDK/Assets/Plugins/iOS/"
-  done
-
+  echo "Building Android SDK..."
   # Build Android SDK
   cd Leanplum-Android-SDK-Unity/
   ./gradlew clean assembleRelease
@@ -296,6 +311,8 @@ main() {
 
   find Leanplum-Unity-Package -name '*.unitypackage' -delete
   find Leanplum-Unity-SDK/Assets/Plugins/ -name '*.aar' -delete
+
+  prepare_ios $APPLE_SDK_VERSION
 
   build
 


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2632](https://wizrocket.atlassian.net/browse/SDK-2632)
People Involved   | @nzagorchev 

## Background
Leanplum iOS SDK Frameworks are now zipped in `Leanplum.zip` file. All dependencies need to be added to the iOS Plugin.

## Implementation
- Use `Leanplum.zip` file. Add Leanplum, CleverTapSDK and SDWebImage xcframeworks. This zip also contains Leanplum Location xcframeworks which are not included by default and should not be added to Unity.
- Update `LeanplumApplePostProcessor`:
 - Set the correct slice based on `BuildTarget` for all frameworks
 - Disable bitcode for all Unity targets since it is now deprecated
 - Remove build script for signing - no longer needed with the new setup
- Delete remove-simulator architecture option since it is no longer needed with xcframeworks.
## Testing steps

## Is this change backwards-compatible?
