### PR TITLE
Fix userId and newUserId args

### DIFF
--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
@@ -1,5 +1,5 @@
 //
-// Copyright 2022, Leanplum, Inc.
+// Copyright 2023, Leanplum, Inc.
 //
 //  Licensed to the Apache Software Foundation (ASF) under one
 //  or more contributor license agreements.  See the NOTICE file

--- a/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
+++ b/Leanplum-Unity-SDK/Assets/LeanplumSDK/Native/LeanplumNative.cs
@@ -582,18 +582,19 @@ namespace LeanplumSDK
             }
             ApiConfig.DeviceId = deviceId;
 
-            // load saved inbox messages
+            // Load saved inbox messages
             if (Inbox is LeanplumInboxNative native)
             {
                 native.Load();
             }
 
-            // Don't overwrite UserID if it was set previously if Start()
-            // was called without a new UserID.
-            if (!string.IsNullOrEmpty(ApiConfig.UserId))
+            // Do not overwrite UserID if it was previously set (and loaded from cache)
+            // Set only if Start() was called with a UserID.
+            if (!string.IsNullOrEmpty(userId))
             {
                 ApiConfig.UserId = userId;
             }
+            // Fallback to DeviceId
             if (string.IsNullOrEmpty(ApiConfig.UserId))
             {
                 ApiConfig.UserId = deviceId;
@@ -1084,7 +1085,9 @@ namespace LeanplumSDK
             }
             if (!string.IsNullOrEmpty(newUserId))
             {
+                parameters[Constants.Params.USER_ID] = Leanplum.ApiConfig.UserId;
                 parameters[Constants.Params.NEW_USER_ID] = newUserId;
+                ApiConfig.UserId = newUserId;
                 VarCache.SaveDiffs();
             }
 
@@ -1092,15 +1095,6 @@ namespace LeanplumSDK
                 .AndParameters(parameters)
                 .Create();
             Leanplum.RequestSender.Send(request);
-
-            if (!string.IsNullOrEmpty(newUserId))
-            {
-                ApiConfig.UserId = newUserId;
-                if (_hasStarted)
-                {
-                    VarCache.SaveDiffs();
-                }
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2979](https://wizrocket.atlassian.net/browse/SDK-2979)
JIRA Issue        | [SDK-767](https://leanplum.atlassian.net/browse/SDK-767)
People Involved   | @nzagorchev 

## Background
Unity Native - Fix the `userId` argument in `SetUserId` and `Start` when setting a new user id.
## Implementation

## Testing steps

## Is this change backwards-compatible?


[SDK-767]: https://leanplum.atlassian.net/browse/SDK-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ