### PR TITLE
Add Unity 6 application entry point note to CleverTap integration docs

### DIFF
--- a/Docs/Android-Instructions.md
+++ b/Docs/Android-Instructions.md
@@ -82,6 +82,17 @@ dependencies {
         </application>
     </manifest>
    ```
+    #### Unity 6 – Application Entry Point Consideration
+    In **Unity 6**, the Android Player settings provide two application entry point options:
+
+    - **Activity**
+    - **GameActivity**
+
+    For CleverTap integration, ensure that the **Activity** option is selected in:
+
+    ```
+    Project Settings → Player → Android → Others Settings → Appication Entry Point
+    ```
 2. Use CleverTap Unity API after `Leanplum.CleverTapInstanceReady` event is received:
     ```csharp
         Leanplum.CleverTapInstanceReady += () =>

--- a/Docs/Migration-V7.md
+++ b/Docs/Migration-V7.md
@@ -87,6 +87,17 @@ Leanplum SDK 7.0.0 has structural changes to its Android project setup, which en
         </application>
     </manifest>
    ```
+    #### Unity 6 – Application Entry Point Consideration
+    In **Unity 6**, the Android Player settings provide two application entry point options:
+
+    - **Activity**
+    - **GameActivity**
+
+    For CleverTap integration, ensure that the **Activity** option is selected in:
+
+    ```
+    Project Settings → Player → Android → Others Settings → Appication Entry Point
+    ```
 2. Use CleverTap Unity API after `Leanplum.CleverTapInstanceReady` event is received:
     ```csharp
         Leanplum.CleverTapInstanceReady += () =>


### PR DESCRIPTION
Added a new subsection under the CleverTap Integration Update section to clarify Unity 6 Application Entry Point settings. 

The update instructs developers to select the Activity option (instead of GameActivity) when using CleverTap with Leanplum, ensuring correct configuration in Unity 6 Android Player settings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Unity 6 Android Player "Application Entry Point" guidance (select Activity) to CleverTap integration docs.
> 
> - **Docs (Android/CleverTap integration)**:
>   - Update `Docs/Android-Instructions.md` and `Docs/Migration-V7.md` with a new subsection: *Unity 6 – Application Entry Point Consideration*.
>     - Instructs selecting **Activity** (not GameActivity) in Unity 6: `Project Settings → Player → Android → Others Settings → Appication Entry Point`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d1c0a9fe37548812d67a77f2439a53f91e66c70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->